### PR TITLE
Not saving cache in new thread

### DIFF
--- a/ktRssReader/src/main/java/tw/ktrssreader/KtRssReader.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/KtRssReader.kt
@@ -71,9 +71,7 @@ object Reader {
             val xml = fetcher.fetch(url = url, charset = charset)
             val parser = KtRssProvider.provideParser<T>()
             val channel = parser.parse(xml)
-            ThreadUtils.runOnNewThread(treadName = "[read cache]") {
-                rssCache.saveCache(url = url, channel = channel)
-            }
+            rssCache.saveCache(url = url, channel = channel)
             channel
         } else {
             logD(logTag, "[read] use local cache")

--- a/ktRssReader/src/test/java/tw/ktrssreader/KtRssReaderLocalTest.kt
+++ b/ktRssReader/src/test/java/tw/ktrssreader/KtRssReaderLocalTest.kt
@@ -56,9 +56,6 @@ class KtRssReaderLocalTest {
             every { mockFetcher.fetch(url = fakeUrl, charset = any()) } returns fakeXmlContent
             mockkConstructor(RssStandardParser::class)
             every { anyConstructed<RssStandardParser>().parse(fakeXmlContent) } returns expected
-            every { ThreadUtils.runOnNewThread(any(), any()) } answers {
-                mockRssCache.saveCache(fakeUrl, expected)
-            }
 
             block(expected)
         }
@@ -94,9 +91,6 @@ class KtRssReaderLocalTest {
             every { mockFetcher.fetch(any(), any()) } returns fakeXmlContent
             mockkConstructor(RssStandardParser::class)
             every { anyConstructed<RssStandardParser>().parse(fakeXmlContent) } returns expected
-            every { ThreadUtils.runOnNewThread(any(), any()) } answers {
-                mockRssCache.saveCache(fakeUrl, expected)
-            }
 
             block(expected)
         }


### PR DESCRIPTION
當使用者拿到 Remote 的 channel
會因為儲存 cache 失敗而又會 catch 到一個新的error，這樣有點奇怪
所以等儲存完 cache ，再把 channel return 回去。