### PR TITLE
Modify the interface of Parser to integrate the new custom parser.

### DIFF
--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
@@ -55,13 +55,14 @@ import tw.ktrssreader.model.item.Category
 import tw.ktrssreader.model.item.RssStandardItemData
 import tw.ktrssreader.utils.logD
 import java.io.IOException
+import kotlin.reflect.KClass
 
 
 class AutoMixParser : ParserBase<AutoMixChannelData>() {
 
     override val logTag: String = AutoMixParser::class.java.simpleName
 
-    override fun parse(xml: String) = parseAutoMixChannel(xml)
+    override fun parse(xml: String, kClass: KClass<AutoMixChannelData>?) = parseAutoMixChannel(xml)
 
     /**
      * The priority of reading tags as the following sequence:

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/CustomPropertyParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/CustomPropertyParser.kt
@@ -16,8 +16,10 @@
 
 package tw.ktrssreader.parser
 
-class CustomPropertyParser<T>: Parser<T> {
-    override fun parse(xml: String): T {
+import kotlin.reflect.KClass
+
+class CustomPropertyParser<T : Any>: Parser<T> {
+    override fun parse(xml: String, kClass: KClass<T>?): T {
         TODO("Not yet implemented")
     }
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/GoogleParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/GoogleParser.kt
@@ -38,12 +38,13 @@ import tw.ktrssreader.model.item.GoogleItemData
 import tw.ktrssreader.model.item.RssStandardItem
 import tw.ktrssreader.utils.logD
 import java.io.IOException
+import kotlin.reflect.KClass
 
 class GoogleParser : ParserBase<GoogleChannelData>() {
 
     override val logTag: String = GoogleParser::class.java.simpleName
 
-    override fun parse(xml: String) = parserGoogleChannel(xml)
+    override fun parse(xml: String, kClass: KClass<GoogleChannelData>?) = parserGoogleChannel(xml)
 
     private fun parserGoogleChannel(xml: String): GoogleChannelData {
         val standardChannel = parseStandardChannel(xml)

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/ITunesParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/ITunesParser.kt
@@ -47,12 +47,13 @@ import tw.ktrssreader.model.item.ITunesItemData
 import tw.ktrssreader.model.item.RssStandardItem
 import tw.ktrssreader.utils.logD
 import java.io.IOException
+import kotlin.reflect.KClass
 
 class ITunesParser : ParserBase<ITunesChannelData>() {
 
     override val logTag: String = ITunesParser::class.java.simpleName
 
-    override fun parse(xml: String) = parseITunesChannel(xml)
+    override fun parse(xml: String, kClass: KClass<ITunesChannelData>?) = parseITunesChannel(xml)
 
     private fun parseITunesChannel(xml: String): ITunesChannelData {
         val standardChannel = parseStandardChannel(xml)

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/Parser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/Parser.kt
@@ -16,6 +16,8 @@
 
 package tw.ktrssreader.parser
 
-interface Parser<out T> {
-    fun parse(xml: String): T
+import kotlin.reflect.KClass
+
+interface Parser<T : Any> {
+    fun parse(xml: String, kClass: KClass<T>? = null): T
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/ParserBase.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/ParserBase.kt
@@ -66,7 +66,7 @@ import tw.ktrssreader.utils.logW
 import java.io.ByteArrayInputStream
 import java.io.IOException
 
-abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
+abstract class ParserBase<T : Any> : Parser<T> {
 
     abstract val logTag: String
 

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/RssStandardParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/RssStandardParser.kt
@@ -19,13 +19,12 @@ package tw.ktrssreader.parser
 import org.xmlpull.v1.XmlPullParserException
 import tw.ktrssreader.model.channel.RssStandardChannel
 import kotlin.jvm.Throws
+import kotlin.reflect.KClass
 
 class RssStandardParser : ParserBase<RssStandardChannel>() {
 
     override val logTag: String = RssStandardParser::class.java.simpleName
 
     @Throws(XmlPullParserException::class)
-    override fun parse(xml: String): RssStandardChannel {
-        return parseStandardChannel(xml)
-    }
+    override fun parse(xml: String, kClass: KClass<RssStandardChannel>?) = parseStandardChannel(xml)
 }


### PR DESCRIPTION
- Modify the interface of Parser to integrate the new custom parser.
- Since we need `KClass` for reflecting the custom class, I think it's better to put an additional argument in the `parse()` method.
