### PR TITLE
Arrange cache flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ class MyApplication : Application() {
 ```kotlin
 val result: ITunesChannelData = Reader.read<ITunesChannelData>(rssSource) {
     charset = Charsets.UTF_8
-    useRemote = true
+    useCache = false
     expiredTimeMillis = 600000L
 }
 ```
 
 * `charset`: Specify an encoding charset, if it's not set, it will use the charset from the RSS source.
-* `useRemote`: Pull data from cache or remote server.
+* `useCache`: Pull data from cache or remote server. The default setting is set to true.
+* `flushCache`: Clear the specific cache by URL.
 * `expiredTimeMillis`: The cache expire time in milliseconds.
 
 #### With Flow

--- a/app/src/main/java/tw/ktrssreader/MainActivity.kt
+++ b/app/src/main/java/tw/ktrssreader/MainActivity.kt
@@ -78,25 +78,25 @@ class MainActivity : AppCompatActivity() {
                 val channel = when {
                     rbRssStandard.isChecked -> {
                         Reader.read<RssStandardChannelData>(etRss.text.toString()) {
-                            useRemote = rbCacheNo.isChecked
+                            useCache = rbCacheYes.isChecked
                             charset = Charset.forName(etCharset.text.toString())
                         }
                     }
                     rbRssItunes.isChecked -> {
                         Reader.read<ITunesChannelData>(etRss.text.toString()) {
-                            useRemote = rbCacheNo.isChecked
+                            useCache = rbCacheYes.isChecked
                             charset = Charset.forName(etCharset.text.toString())
                         }
                     }
                     rbRssGooglePlay.isChecked -> {
                         Reader.read<GoogleChannelData>(etRss.text.toString()) {
-                            useRemote = rbCacheNo.isChecked
+                            useCache = rbCacheYes.isChecked
                             charset = Charset.forName(etCharset.text.toString())
                         }
                     }
                     rbRssAutoMix.isChecked -> {
                         Reader.read<AutoMixChannelData>(etRss.text.toString()) {
-                            useRemote = rbCacheNo.isChecked
+                            useCache = rbCacheYes.isChecked
                             charset = Charset.forName(etCharset.text.toString())
                         }
                     }
@@ -127,25 +127,25 @@ class MainActivity : AppCompatActivity() {
                     when {
                         rbRssStandard.isChecked -> {
                             Reader.coRead<RssStandardChannelData>(etRss.text.toString()) {
-                                useRemote = rbCacheNo.isChecked
+                                useCache = rbCacheYes.isChecked
                                 charset = Charset.forName(etCharset.text.toString())
                             }
                         }
                         rbRssItunes.isChecked -> {
                             Reader.coRead<ITunesChannelData>(etRss.text.toString()) {
-                                useRemote = rbCacheNo.isChecked
+                                useCache = rbCacheYes.isChecked
                                 charset = Charset.forName(etCharset.text.toString())
                             }
                         }
                         rbRssGooglePlay.isChecked -> {
                             Reader.coRead<GoogleChannelData>(etRss.text.toString()) {
-                                useRemote = rbCacheNo.isChecked
+                                useCache = rbCacheYes.isChecked
                                 charset = Charset.forName(etCharset.text.toString())
                             }
                         }
                         rbRssAutoMix.isChecked -> {
                             Reader.coRead<AutoMixChannelData>(etRss.text.toString()) {
-                                useRemote = rbCacheNo.isChecked
+                                useCache = rbCacheYes.isChecked
                                 charset = Charset.forName(etCharset.text.toString())
                             }
                         }
@@ -168,25 +168,25 @@ class MainActivity : AppCompatActivity() {
             val flowChannel = when {
                 rbRssStandard.isChecked -> {
                     Reader.flowRead<RssStandardChannelData>(etRss.text.toString()) {
-                        useRemote = rbCacheNo.isChecked
+                        useCache = rbCacheYes.isChecked
                         charset = Charset.forName(etCharset.text.toString())
                     }
                 }
                 rbRssItunes.isChecked -> {
                     Reader.flowRead<ITunesChannelData>(etRss.text.toString()) {
-                        useRemote = rbCacheNo.isChecked
+                        useCache = rbCacheYes.isChecked
                         charset = Charset.forName(etCharset.text.toString())
                     }
                 }
                 rbRssGooglePlay.isChecked -> {
                     Reader.flowRead<GoogleChannelData>(etRss.text.toString()) {
-                        useRemote = rbCacheNo.isChecked
+                        useCache = rbCacheYes.isChecked
                         charset = Charset.forName(etCharset.text.toString())
                     }
                 }
                 rbRssAutoMix.isChecked -> {
                     Reader.flowRead<AutoMixChannelData>(etRss.text.toString()) {
-                        useRemote = rbCacheNo.isChecked
+                        useCache = rbCacheYes.isChecked
                         charset = Charset.forName(etCharset.text.toString())
                     }
                 }

--- a/ktRssReader/src/androidTest/java/tw/ktrssreader/database/ChannelDaoTest.kt
+++ b/ktRssReader/src/androidTest/java/tw/ktrssreader/database/ChannelDaoTest.kt
@@ -58,4 +58,19 @@ class ChannelDaoTest : DaoTestBase() {
         subject.getChannel(fakeUrl2, fakeType) shouldBe null
         subject.getChannel(fakeUrl3, fakeType) shouldBe null
     }
+
+    @Test
+    fun testDeleteCacheByUrl() {
+        val fakeUrl1 = "fakeUrl1"
+        val fakeUrl2 = "fakeUrl2"
+        val subject = database.channelDao()
+        val entity1 = ChannelEntity(fakeUrl1, fakeType, fakeChannelByteArray, fakeTime)
+        val entity2 = ChannelEntity(fakeUrl2, fakeType, fakeChannelByteArray, fakeTime)
+
+        subject.insert(entity1)
+        subject.insert(entity2)
+        subject.deleteByUrl(fakeUrl1)
+        subject.getChannel(fakeUrl1, fakeType) shouldBe null
+        subject.getChannel(fakeUrl2, fakeType) shouldNotBe null
+    }
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/KtRssReader.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/KtRssReader.kt
@@ -23,7 +23,7 @@ import tw.ktrssreader.constant.Const
 import tw.ktrssreader.model.channel.RssStandardChannel
 import tw.ktrssreader.provider.KtRssProvider
 import tw.ktrssreader.utils.ThreadUtils
-import tw.ktrssreader.utils.catchOrNull
+import tw.ktrssreader.utils.tryCatch
 import tw.ktrssreader.utils.logD
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -71,22 +71,22 @@ object Reader {
         )
 
         if (flushCache) {
-            catchOrNull { rssCache.removeCache(url) }
+            tryCatch { rssCache.removeCache(url) }
         }
 
-        if (cacheChannel == null) {
+        return if (cacheChannel == null) {
             logD(logTag, "[read] fetch remote data")
             val fetcher = KtRssProvider.provideXmlFetcher()
             val xml = fetcher.fetch(url = url, charset = charset)
             val parser = KtRssProvider.provideParser<T>()
             val channel = parser.parse(xml)
             if (useCache) {
-                catchOrNull { rssCache.saveCache(url = url, channel = channel) } ?: return channel
+                tryCatch { rssCache.saveCache(url = url, channel = channel) }
             }
-            return channel
+            channel
         } else {
             logD(logTag, "[read] use local cache")
-            return cacheChannel
+            cacheChannel
         }
     }
 

--- a/ktRssReader/src/main/java/tw/ktrssreader/cache/DatabaseRssCache.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/cache/DatabaseRssCache.kt
@@ -56,4 +56,10 @@ class DatabaseRssCache<T : RssStandardChannel> : RssCache<T> {
             )
         )
     }
+
+    override fun removeCache(url: String) {
+        logD(logTag, "[removeCache] url: $url")
+
+        dao.deleteByUrl(url)
+    }
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/cache/RssCache.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/cache/RssCache.kt
@@ -22,4 +22,5 @@ import tw.ktrssreader.model.channel.RssStandardChannel
 interface RssCache<out T : RssStandardChannel> {
     fun readCache(url: String, type: @Const.ChannelType Int, expiredTimeMillis: Long): T?
     fun saveCache(url: String, channel: RssStandardChannel)
+    fun removeCache(url: String)
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/config/KtRssReaderConfig.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/config/KtRssReaderConfig.kt
@@ -23,7 +23,9 @@ import kotlin.time.days
 class KtRssReaderConfig {
     var charset: Charset? = null
 
-    var useRemote: Boolean = false
+    var useCache: Boolean = true
+
+    var flushCache: Boolean = false
 
     @ExperimentalTime
     var expiredTimeMillis: Long = 1.days.toLongMilliseconds()

--- a/ktRssReader/src/main/java/tw/ktrssreader/persistence/db/dao/ChannelDao.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/persistence/db/dao/ChannelDao.kt
@@ -26,6 +26,9 @@ interface ChannelDao : DaoBase<ChannelEntity> {
     @Query("SELECT * FROM CHANNEL_TABLE WHERE url = :url and type = :type")
     fun getChannel(url: String, type: Int): ChannelEntity?
 
+    @Query("DELETE FROM CHANNEL_TABLE WHERE url = :url")
+    fun deleteByUrl(url: String)
+
     @Query("DELETE FROM CHANNEL_TABLE")
     fun clearAll()
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/utils/TopLevelFunctions.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/utils/TopLevelFunctions.kt
@@ -37,11 +37,12 @@ fun logW(tag: String, message: String) {
     if (KtRssReaderGlobalConfig.enableLog) Log.w("$TAG_PREFIX$tag", message)
 }
 
-inline fun catchOrNull(block: () -> Unit) = try {
-    block()
-} catch (e: Exception) {
-    e.printStackTrace()
-    null
+inline fun tryCatch(block: () -> Unit) {
+    try {
+        block()
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
 }
 
 fun <T> T.convertToByteArray(): ByteArray {

--- a/ktRssReader/src/main/java/tw/ktrssreader/utils/TopLevelFunctions.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/utils/TopLevelFunctions.kt
@@ -37,6 +37,13 @@ fun logW(tag: String, message: String) {
     if (KtRssReaderGlobalConfig.enableLog) Log.w("$TAG_PREFIX$tag", message)
 }
 
+inline fun catchOrNull(block: () -> Unit) = try {
+    block()
+} catch (e: Exception) {
+    e.printStackTrace()
+    null
+}
+
 fun <T> T.convertToByteArray(): ByteArray {
     return ByteArrayOutputStream().use { bos ->
         val oos = ObjectOutputStream(bos)

--- a/ktRssReader/src/test/java/tw/ktrssreader/cache/DatabaseRssCacheLocalTest.kt
+++ b/ktRssReader/src/test/java/tw/ktrssreader/cache/DatabaseRssCacheLocalTest.kt
@@ -104,4 +104,11 @@ class DatabaseRssCacheLocalTest {
             })
         }
     }
+
+    @Test
+    fun `Remove cache`() {
+        subject.removeCache(fakeUrl)
+
+        verify { mockDao.deleteByUrl(fakeUrl) }
+    }
 }


### PR DESCRIPTION
- 新增 method config : flushCache(url)，主要用來清掉舊的 cache

- 當 useCache為 true 才要去存 cache  (若cache 存失敗會 return 解析出來的物件回去)
 