### PR TITLE
Add raw tags and tag order support.

### DIFF
--- a/annotation/src/main/java/tw/ktrssreader/annotation/Annotations.kt
+++ b/annotation/src/main/java/tw/ktrssreader/annotation/Annotations.kt
@@ -29,10 +29,7 @@ annotation class RssTag(
 
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.SOURCE)
-annotation class RssAttribute(
-    val name: String = "",
-    val order: Array<OrderType> = [OrderType.RSS_STANDARD, OrderType.ITUNES, OrderType.GOOGLE]
-)
+annotation class RssAttribute(val name: String = "")
 
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.SOURCE)

--- a/processor/src/main/java/tw/ktrssreader/processor/ParseData.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/ParseData.kt
@@ -19,13 +19,13 @@ package tw.ktrssreader.processor
 import javax.lang.model.element.Element
 
 data class ParseData(
-    val tag: String,
     val type: String?,
     val rawType: String?,
     val dataType: DataType,
     val listItemType: String?,
     val packageName: String?,
     val processorElement: Element,
+    val tagCandidates: List<String> = listOf()
 )
 
 enum class DataType {

--- a/processor/src/main/java/tw/ktrssreader/processor/ParserGenerator.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/ParserGenerator.kt
@@ -152,7 +152,7 @@ class ParserGenerator(
         val result = mutableMapOf<String, Any?>()
         rootElement.enclosedElements.forEach { child ->
             if (child.kind != ElementKind.METHOD
-                || !child.simpleName.contains(GET_PREFIX)
+                || !child.simpleName.startsWith(GET_PREFIX)
                 || !child.simpleName.contains(ANNOTATION_SIGN)
             ) return@forEach
 
@@ -181,7 +181,7 @@ class ParserGenerator(
         nameToAnnotation: Map<String, Any?>
     ) {
         if (child.kind != ElementKind.METHOD
-            || !child.simpleName.contains(GET_PREFIX)
+            || !child.simpleName.startsWith(GET_PREFIX)
             || child.simpleName.contains(ANNOTATION_SIGN)
         ) return
 
@@ -349,8 +349,8 @@ class ParserGenerator(
 
     private fun String.getVariableName(tag: String): String {
         return when {
-            tag.contains(GOOGLE_PREFIX) -> "$this${GOOGLE_PREFIX.capitalize(Locale.ROOT)}"
-            tag.contains(ITUNES_PREFIX) -> "$this${ITUNES_PREFIX.capitalize(Locale.ROOT)}"
+            tag.startsWith(GOOGLE_PREFIX) -> "$this${GOOGLE_PREFIX.capitalize(Locale.ROOT)}"
+            tag.startsWith(ITUNES_PREFIX) -> "$this${ITUNES_PREFIX.capitalize(Locale.ROOT)}"
             else -> this
         }
     }

--- a/processor/src/main/java/tw/ktrssreader/processor/ParserGenerator.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/ParserGenerator.kt
@@ -17,13 +17,16 @@
 package tw.ktrssreader.processor
 
 import com.squareup.kotlinpoet.*
+import tw.ktrssreader.annotation.OrderType
 import tw.ktrssreader.annotation.RssAttribute
+import tw.ktrssreader.annotation.RssRawData
 import tw.ktrssreader.annotation.RssTag
 import tw.ktrssreader.processor.const.*
 import tw.ktrssreader.processor.util.*
 import java.util.*
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
 
 class ParserGenerator(
     private val element: Element,
@@ -39,6 +42,8 @@ class ParserGenerator(
     private val readStringMemberName = MemberName(extensionFullPath, METHOD_READ_STRING)
     private val getParserMemberName = MemberName(extensionFullPath, METHOD_GET_PARSER)
     private val booleanConversionMemberName = MemberName(extensionFullPath, METHOD_TO_BOOLEAN)
+
+    private var topLevelCandidateOrder = emptyArray<OrderType>()
 
     override fun generate(): FileSpec {
         val generatedClassName = "${element.simpleName}$PARSER_SUFFIX"
@@ -87,17 +92,24 @@ class ParserGenerator(
 
     private fun getClassFunSpec(rootElement: Element, outputClassName: String): FunSpec {
         val outputClass = ClassName(rootElement.getPackage(), outputClassName)
-        val annotation = rootElement.getAnnotation(RssTag::class.java)
-        val tagName = annotation?.name?.takeIfNotEmpty() ?: rootElement.simpleName.toString()
+        val rssTag = rootElement.getAnnotation(RssTag::class.java)
+        val rssRawData = rootElement.getAnnotation(RssRawData::class.java)
+        if (rssTag != null && rssRawData != null) {
+            logger.error(
+                "@RssTag and @RssRawData should not be used on the same class!",
+                rootElement
+            )
+        }
+        val tagName = rssTag?.name?.takeIfNotEmpty() ?: rootElement.simpleName.toString()
         val funSpec = FunSpec.builder(tagName.getFuncName())
             .receiver(xmlParserClass)
             .returns(outputClass)
         val propertyToParseData = mutableMapOf<String, ParseData>()
+        topLevelCandidateOrder =
+            rssTag?.order ?: arrayOf(OrderType.RSS_STANDARD, OrderType.ITUNES, OrderType.GOOGLE)
 
-        rootElement.enclosedElements.forEach {
-            preProcessParseData(child = it, parseDataMap = propertyToParseData)
-        }
-        funSpec.addStatement("require(XmlPullParser.START_TAG, null, \"$tagName\")")
+        val annotations = preProcessAnnotations(rootElement)
+        rootElement.enclosedElements.forEach { preProcessParseData(it, propertyToParseData, annotations) }
         propertyToParseData.forEach { generateVariableStatement(it, funSpec) }
         funSpec.addCode(
             """
@@ -114,56 +126,76 @@ class ParserGenerator(
             |       else -> %M()
             |  }
             |}
-            |require(XmlPullParser.END_TAG, null, "$tagName")
             |return $outputClassName(
         """.trimMargin(),
             skipMemberName
         )
         // Generate constructor statements
-        propertyToParseData.forEach { funSpec.addStatement("${it.key} = ${it.key},") }
+        propertyToParseData.forEach {
+            val stringBuilder = StringBuilder()
+            it.value.tagCandidates.forEach { tag ->
+                val variableName = it.key.getVariableName(tag)
+                if (stringBuilder.isEmpty()) {
+                    stringBuilder.append(variableName)
+                } else {
+                    stringBuilder.append(" ?: $variableName")
+                }
+            }
+            funSpec.addStatement("\t${it.key} = $stringBuilder,")
+        }
 
         funSpec.addStatement(")")
         return funSpec.build()
     }
 
-    private fun preProcessParseData(
-        child: Element,
-        parseDataMap: MutableMap<String, ParseData>
-    ) {
-        if (child.kind == ElementKind.METHOD
-            && child.simpleName.contains(GET_PREFIX)
-            && child.simpleName.contains(ANNOTATION_SIGN)
-        ) {
+    private fun preProcessAnnotations(rootElement: Element): Map<String, Any?> {
+        val result = mutableMapOf<String, Any?>()
+        rootElement.enclosedElements.forEach { child ->
+            if (child.kind != ElementKind.METHOD
+                || !child.simpleName.contains(GET_PREFIX)
+                || !child.simpleName.contains(ANNOTATION_SIGN)
+            ) return@forEach
+
             // Extract name which is started with 'get' (length = 3).
             // The child simple name example: getList$annotations
             val nameFromMethod = child.simpleName.substring(3)
                 .decapitalize(Locale.ROOT)
                 .substringBeforeLast('$')
-            if (parseDataMap.containsKey(nameFromMethod)) {
-                val rssTag = child.getAnnotation(RssTag::class.java)
-                val rssAttribute = child.getAnnotation(RssAttribute::class.java)
-                val tag = rssAttribute?.name?.takeIfNotEmpty()
-                    ?: rssTag?.name?.takeIfNotEmpty()
-                    ?: nameFromMethod
-                val dataType = if (rssAttribute == null) DataType.LIST else DataType.ATTRIBUTE
-                val clone = parseDataMap[nameFromMethod]
-                    ?.copy(tag = tag, dataType = dataType) ?: return
 
-                parseDataMap[nameFromMethod] = clone
+            val rssTag: RssTag? = child.getAnnotation(RssTag::class.java)
+            val rssAttribute: RssAttribute? = child.getAnnotation(RssAttribute::class.java)
+            val rssRawData: RssRawData? = child.getAnnotation(RssRawData::class.java)
+            val nonNullCount = listOf<Any?>(rssTag, rssAttribute, rssRawData).count { it != null }
+            if (nonNullCount > 1) {
+                logger.error("You can't annotate more than one annotation at a field or property!", child)
             }
+
+            result[nameFromMethod] = rssTag ?: rssAttribute ?: rssRawData
         }
+        return result
+    }
 
-        if (child.kind != ElementKind.FIELD) return
+    private fun preProcessParseData(
+        child: Element,
+        parseDataMap: MutableMap<String, ParseData>,
+        nameToAnnotation: Map<String, Any?>
+    ) {
+        if (child.kind != ElementKind.METHOD
+            || !child.simpleName.contains(GET_PREFIX)
+            || child.simpleName.contains(ANNOTATION_SIGN)
+        ) return
 
-        val name = child.simpleName.toString()
-        val rawType = child.asType()?.toString()
-        val tag = parseDataMap[name]?.tag ?: name
+        // Extract name which is started with 'get' (length = 3).
+        // The child simple name example: getList$annotations
+        val nameFromMethod = child.simpleName.substring(3).decapitalize(Locale.ROOT)
+        val exeElement = child as? ExecutableElement ?: return
+        val rawType = exeElement.returnType.toString()
         val type: String?
         val packageName: String?
-        var dataType = parseDataMap[name]?.dataType
+        val dataType: DataType
         var listItemType: String? = null
 
-        if (rawType?.isListType() == true) {
+        if (rawType.isListType()) {
             listItemType = rawType.extractListType()
             type = rawType
                 .substringBeforeLast('<')
@@ -173,51 +205,24 @@ class ParserGenerator(
                 .substringBeforeLast('.')
             dataType = DataType.LIST
         } else {
-            type = rawType?.extractType()
-            if (dataType == null) {
-                dataType =
-                    if (rawType?.isPrimitive() == true) DataType.PRIMITIVE else DataType.OTHER
+            type = rawType.extractType()
+            dataType = when {
+                nameToAnnotation[nameFromMethod] is RssAttribute -> DataType.ATTRIBUTE
+                rawType.isPrimitive() -> DataType.PRIMITIVE
+                else -> DataType.OTHER
             }
-            packageName = rawType?.substringBeforeLast('.')
+            packageName = rawType.substringBeforeLast('.')
         }
-        parseDataMap[name] = ParseData(
-            tag = tag,
+
+        parseDataMap[nameFromMethod] = ParseData(
             type = type,
             rawType = rawType,
             dataType = dataType,
             listItemType = listItemType,
             packageName = packageName,
             processorElement = child,
+            tagCandidates = getTagCandidates(nameToAnnotation, nameFromMethod, child)
         )
-    }
-
-    private fun generateVariableAssignment(
-        entry: Map.Entry<String, ParseData>,
-        funSpec: FunSpec.Builder
-    ) {
-        val data = entry.value
-        val tag = data.tag
-        val name = entry.key
-        when (data.dataType) {
-            DataType.LIST -> {
-                val listItemType = data.listItemType ?: return
-
-                val memberName = MemberName(listItemType.getGeneratedClassPath(), tag.getFuncName())
-                funSpec.addStatement("\t\t\"$tag\" -> $name.add(%M())", memberName)
-            }
-            DataType.PRIMITIVE -> {
-                val type = data.type ?: return
-                funSpec.addPrimitiveStatement(tagName = tag, variableName = name, typeString = type)
-            }
-            DataType.ATTRIBUTE -> {
-                // Do nothing.
-            }
-            else -> {
-                val type = data.type ?: return
-                val memberName = MemberName(type.getGeneratedClassPath(), tag.getFuncName())
-                funSpec.addStatement("\t\t\"$tag\" -> $name = %M()", memberName)
-            }
-        }
     }
 
     private fun generateVariableStatement(
@@ -227,37 +232,126 @@ class ParserGenerator(
         val name = propertyToParseData.key
         val data = propertyToParseData.value
         val packageName = data.packageName ?: return
+        val type = data.type ?: return
 
-        if (data.dataType == DataType.LIST) {
-            data.listItemType ?: return
+        when (data.dataType) {
+            DataType.LIST -> {
+                data.listItemType ?: return
 
-            val itemClassName = ClassName(packageName, data.listItemType)
-            funSpec.addStatement("var ${name}: ArrayList<%T> = arrayListOf()", itemClassName)
-        } else {
-            val type = data.type ?: return
-
-            when (data.dataType) {
-                DataType.PRIMITIVE -> {
-                    val kClass = type.getKPrimitiveClass() ?: return
-
-                    funSpec.addStatement("var ${name}: %T? = null", kClass)
+                val itemClassName = ClassName(packageName, data.listItemType)
+                data.tagCandidates.forEach { tag ->
+                    funSpec.addStatement("var ${name.getVariableName(tag)}: ArrayList<%T> = arrayListOf()", itemClassName)
                 }
-                DataType.ATTRIBUTE -> {
-                    val kClass = type.getKPrimitiveClass() ?: return
+            }
+            DataType.PRIMITIVE -> {
+                val kClass = type.getKPrimitiveClass() ?: return
 
-                    val statement = "var ${name}: %1T? = getAttributeValue(null, \"${data.tag}\")"
-                        .appendTypeConversion(type)
+                data.tagCandidates.forEach { tag ->
+                    funSpec.addStatement("var ${name.getVariableName(tag)}: %T? = null", kClass)
+                }
+            }
+            DataType.ATTRIBUTE -> {
+                val kClass = type.getKPrimitiveClass() ?: return
+
+                data.tagCandidates.forEach { tag ->
+                    val statement =
+                        "var ${name.getVariableName(tag)}: %1T? = getAttributeValue(null, \"$tag\")"
+                            .appendTypeConversion(type)
                     if (type == Boolean::class.java.simpleName) {
                         funSpec.addStatement(statement, kClass, booleanConversionMemberName)
                     } else {
                         funSpec.addStatement(statement, kClass)
                     }
                 }
-                else -> {
-                    val className = ClassName(packageName, type)
-                    funSpec.addStatement("var ${name}: %T? = null", className)
+            }
+            else -> {
+                val className = ClassName(packageName, type)
+                data.tagCandidates.forEach { tag ->
+                    funSpec.addStatement("var ${name.getVariableName(tag)}: %T? = null", className)
                 }
             }
+        }
+    }
+
+    private fun generateVariableAssignment(
+        entry: Map.Entry<String, ParseData>,
+        funSpec: FunSpec.Builder
+    ) {
+        val data = entry.value
+        val name = entry.key
+        when (data.dataType) {
+            DataType.LIST -> {
+                val listItemType = data.listItemType ?: return
+
+                data.tagCandidates.forEach { tag ->
+                    val memberName =
+                        MemberName(listItemType.getGeneratedClassPath(), tag.getFuncName())
+                    funSpec.addStatement("\t\t\"$tag\" -> ${name.getVariableName(tag)}.add(%M())", memberName)
+                }
+            }
+            DataType.PRIMITIVE -> {
+                val type = data.type ?: return
+
+                data.tagCandidates.forEach { tag ->
+                    funSpec.addPrimitiveStatement(tag, name.getVariableName(tag), type)
+                }
+            }
+            DataType.ATTRIBUTE -> {
+                // Do nothing.
+            }
+            else -> {
+                val type = data.type ?: return
+
+                data.tagCandidates.forEach { tag ->
+                    val memberName = MemberName(type.getGeneratedClassPath(), tag.getFuncName())
+                    funSpec.addStatement("\t\t\"$tag\" -> ${name.getVariableName(tag)} = %M()", memberName)
+                }
+            }
+        }
+    }
+
+    private fun getTagCandidates(
+        nameToAnnotation: Map<String, Any?>,
+        nameFromMethod: String,
+        element: Element
+    ): List<String> {
+
+        fun getTags(order: Array<OrderType>, tag: String): List<String> {
+            return order.map { orderType ->
+                when (orderType) {
+                    OrderType.GOOGLE -> "$GOOGLE_PREFIX:$tag"
+                    OrderType.ITUNES -> "$ITUNES_PREFIX:$tag"
+                    else -> tag
+                }
+            }
+        }
+
+        return when (val annotation = nameToAnnotation[nameFromMethod]) {
+            is RssTag -> {
+                val tag = annotation.name.takeIfNotEmpty() ?: nameFromMethod
+                getTags(annotation.order, tag)
+            }
+            is RssAttribute -> {
+                val tag = annotation.name.takeIfNotEmpty() ?: nameFromMethod
+                listOf(tag)
+            }
+            is RssRawData -> {
+                if (annotation.rawTags.isEmpty()) {
+                    logger.error("You have to put raw tags into @RssRawData!", element)
+                }
+                annotation.rawTags.toList()
+            }
+            else -> {
+                getTags(topLevelCandidateOrder, nameFromMethod)
+            }
+        }
+    }
+
+    private fun String.getVariableName(tag: String): String {
+        return when {
+            tag.contains(GOOGLE_PREFIX) -> "$this${GOOGLE_PREFIX.capitalize(Locale.ROOT)}"
+            tag.contains(ITUNES_PREFIX) -> "$this${ITUNES_PREFIX.capitalize(Locale.ROOT)}"
+            else -> this
         }
     }
 

--- a/processor/src/main/java/tw/ktrssreader/processor/RssAnnotationProcessor.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/RssAnnotationProcessor.kt
@@ -56,7 +56,7 @@ class RssAnnotationProcessor : AbstractProcessor() {
         }
 
         p1?.getElementsAnnotatedWith(RssTag::class.java)?.forEach {
-            if (it != null && it.kind == ElementKind.CLASS) {
+            if (it?.kind == ElementKind.CLASS) {
                 val rssTag = it.getAnnotation(RssTag::class.java)
                 ParserGenerator(
                     element = it,

--- a/processor/src/main/java/tw/ktrssreader/processor/const/ParserConst.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/const/ParserConst.kt
@@ -31,3 +31,6 @@ const val METHOD_SKIP = "skip"
 const val METHOD_GET_PARSER = "getXmlParser"
 const val METHOD_READ_STRING = "readString"
 const val METHOD_TO_BOOLEAN = "toBooleanOrNull"
+
+const val ITUNES_PREFIX = "itunes"
+const val GOOGLE_PREFIX = "googleplay"

--- a/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
@@ -17,6 +17,8 @@
 package tw.ktrssreader.processor.util
 
 import tw.ktrssreader.processor.const.GENERATOR_PACKAGE
+import tw.ktrssreader.processor.const.GOOGLE_PREFIX
+import tw.ktrssreader.processor.const.ITUNES_PREFIX
 import tw.ktrssreader.processor.const.PARSER_SUFFIX
 import java.util.*
 import javax.lang.model.element.Element
@@ -38,7 +40,13 @@ fun String.isListType(): Boolean {
 
 fun String.isPrimitive(): Boolean = primitiveJavaPaths.any { this.contains(it) }
 
-fun String.getFuncName() = "get${this.capitalize(Locale.ROOT)}"
+fun String.getFuncName(): String {
+    return when {
+        this.contains(GOOGLE_PREFIX) || this.contains(ITUNES_PREFIX) ->
+            "get${this.substringAfterLast(':').capitalize(Locale.ROOT)}"
+        else -> "get${this.capitalize(Locale.ROOT)}"
+    }
+}
 
 fun String.getGeneratedClassPath() =
     "${GENERATOR_PACKAGE}.${this.capitalize(Locale.ROOT)}${PARSER_SUFFIX}"

--- a/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
@@ -42,7 +42,7 @@ fun String.isPrimitive(): Boolean = primitiveJavaPaths.any { this.contains(it) }
 
 fun String.getFuncName(): String {
     return when {
-        this.contains(GOOGLE_PREFIX) || this.contains(ITUNES_PREFIX) ->
+        this.startsWith(GOOGLE_PREFIX) || this.startsWith(ITUNES_PREFIX) ->
             "get${this.substringAfterLast(':').capitalize(Locale.ROOT)}"
         else -> "get${this.capitalize(Locale.ROOT)}"
     }

--- a/processor/src/main/java/tw/ktrssreader/processor/util/Logger.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/util/Logger.kt
@@ -17,7 +17,6 @@
 package tw.ktrssreader.processor.util
 
 import javax.annotation.processing.Messager
-import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.Element
 import javax.tools.Diagnostic
 
@@ -31,7 +30,7 @@ class Logger(private val log: Messager) {
         log.printMessage(Diagnostic.Kind.WARNING, "$msg\r\n")
     }
 
-    fun error(msg: String, element: Element, annotation: AnnotationMirror) {
-        log.printMessage(Diagnostic.Kind.ERROR, "$msg\r\n", element, annotation)
+    fun error(msg: String, element: Element) {
+        log.printMessage(Diagnostic.Kind.ERROR, "$msg\r\n", element)
     }
 }


### PR DESCRIPTION
## Modify
- Remove the order of `@RssAttribute`, since it's unnecessary to specify parsing order for attributes. We use the tag level order to parse it.
- Support `@RssRawData`
- Support the order of `@RssTag`
- Remove all `require(XmlPullParser.START_TAG, null, someTag)` statements in parser generator. Because it will throw exceptions if we try to parse raw tags or platform tags.

## Errors in Compile Time
- I used `logger.error(msg, element)` to warn users in compile time. I will automatically throw exceptions during compiling code.

## TODO
- The API generator of the custom parsers is coming right up.
- Add tests for custom parsers.