### PR TITLE
Improve AutoMixParser performance

### DIFF
--- a/TAGS_MAPPING_TABLE.md
+++ b/TAGS_MAPPING_TABLE.md
@@ -23,7 +23,7 @@
 |skipDays|skipDays|skipDays|skipDays|
 |simpleTitle|-|itunes:title|-|
 |explicit|-|itunes:explict|googleplay:explicit|
-|email|-|itunes:email|-|
+|email|-|itunes:email|googleplay:email|
 |author|-|itunes:author|googleplay:author|
 |owner|-|itunes:owner|googleplay:owner|
 |type|-|itunes:type|-|
@@ -42,7 +42,7 @@
 |pubDate|pubDate|pubDate|pubDate|
 |description|description|description|googleplay:description|
 |link|link|link|link|
-|author|author|author|author|
+|author|author|itunes:author|author|
 |categories|category|category|category|
 |comments|comments|comments|comments|
 |source|source|source|source|

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
@@ -137,6 +137,7 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
         return (rssStandardMap[key] ?: iTunesMap[key] ?: googlePlayMap[key]) as? R
     }
 
+    @Throws(IOException::class, XmlPullParserException::class)
     private fun parseTag(xml: String) = parseChannel<Unit>(xml = xml) {
         require(XmlPullParser.START_TAG, null, ParserConst.CHANNEL)
 
@@ -343,7 +344,11 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
                 val name: String? = readString(tagName = CATEGORY)
                 require(XmlPullParser.END_TAG, null, CATEGORY)
                 logD(logTag, "[readCategory]: name = $name, domain = $domain")
-                return if (name == null && domain == null) null else Category(name = name, domain = domain)
+                return if (name == null && domain == null) {
+                    null
+                } else {
+                    Category(name = name, domain = domain)
+                }
             }
             else -> return null
         }
@@ -462,14 +467,26 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
     }
 
     private fun Image?.replaceInvalidUrlByPriority(vararg priorityHref: String?): Image? {
-        if (this == null) return null
-        if (priorityHref.isNullOrEmpty() || url != null) return this
-
-        return Image(link = link, title = title, url = priorityHref.find { it != null }, description = description, height = height, width = width)
+        if (this == null || priorityHref.isNullOrEmpty() || url != null) return this
+        return Image(
+            link = link,
+            title = title,
+            url = priorityHref.find { it != null },
+            description = description,
+            height = height,
+            width = width
+        )
     }
 
     private fun hrefToImage(href: String?): Image? {
         href ?: return null
-        return Image(link = null, title = null, url = href, description = null, height = null, width = null)
+        return Image(
+            link = null,
+            title = null,
+            url = href,
+            description = null,
+            height = null,
+            width = null
+        )
     }
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
@@ -211,23 +211,23 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
                 ITUNES_IMAGE -> iTunesImageHref = readImageHref(ITUNES_IMAGE)
                 ITUNES_CATEGORY -> readCategory(ITUNES_CATEGORY)?.let { iTunesCategories.add(it) }
                 ITUNES_TITLE -> iTunesSimpleTitle = readString(ITUNES_TITLE)
-                ITUNES_EXPLICIT -> iTunesExplicit = readString(ITUNES_EXPLICIT)?.convertYesNo()
+                ITUNES_EXPLICIT -> iTunesExplicit = readString(ITUNES_EXPLICIT)?.toBoolOrNull()
                 ITUNES_EMAIL -> iTunesEmail = readString(ITUNES_EMAIL)
                 ITUNES_AUTHOR -> iTunesAuthor = readString(ITUNES_AUTHOR)
                 ITUNES_OWNER -> iTunesOwner = readITunesOwner()
                 ITUNES_TYPE -> iTunesType = readString(ITUNES_TYPE)
                 ITUNES_NEW_FEED_URL -> iTunesNewFeedUrl = readString(ITUNES_NEW_FEED_URL)
-                ITUNES_BLOCK -> iTunesBlock = readString(ITUNES_BLOCK)?.convertYesNo()
-                ITUNES_COMPLETE -> iTunesComplete = readString(ITUNES_COMPLETE)?.convertYesNo()
+                ITUNES_BLOCK -> iTunesBlock = readString(ITUNES_BLOCK)?.toBoolOrNull()
+                ITUNES_COMPLETE -> iTunesComplete = readString(ITUNES_COMPLETE)?.toBoolOrNull()
 
                 GOOGLE_DESCRIPTION -> googleDescription = readString(GOOGLE_DESCRIPTION)
                 GOOGLE_IMAGE -> googleImageHref = readImageHref(GOOGLE_IMAGE)
                 GOOGLE_CATEGORY -> googleCategories.add(readCategory(GOOGLE_CATEGORY))
-                GOOGLE_EXPLICIT -> googleExplicit = readString(GOOGLE_EXPLICIT)?.convertYesNo()
+                GOOGLE_EXPLICIT -> googleExplicit = readString(GOOGLE_EXPLICIT)?.toBoolOrNull()
                 GOOGLE_EMAIL -> googleEmail = readString(GOOGLE_EMAIL)
                 GOOGLE_AUTHOR -> googleAuthor = readString(GOOGLE_AUTHOR)
                 GOOGLE_OWNER -> googleOwner = readGoogleOwner()
-                GOOGLE_BLOCK -> googleBlock = readString(GOOGLE_BLOCK)?.convertYesNo()
+                GOOGLE_BLOCK -> googleBlock = readString(GOOGLE_BLOCK)?.toBoolOrNull()
 
                 else -> skip()
             }
@@ -430,15 +430,15 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
                 ITUNES_TITLE -> iTunesSimpleTitle = readString(ITUNES_TITLE)
                 ITUNES_DURATION -> iTunesDuration = readString(ITUNES_DURATION)
                 ITUNES_IMAGE -> iTunesImageHref = readImageHref(ITUNES_IMAGE)
-                ITUNES_EXPLICIT -> iTunesExplicit = readString(ITUNES_EXPLICIT)?.convertYesNo()
+                ITUNES_EXPLICIT -> iTunesExplicit = readString(ITUNES_EXPLICIT)?.toBoolOrNull()
                 ITUNES_EPISODE -> iTunesEpisode = readString(ITUNES_EPISODE)?.toIntOrNull()
                 ITUNES_SEASON -> iTunesSeason = readString(ITUNES_SEASON)?.toIntOrNull()
                 ITUNES_EPISODE_TYPE -> iTunesEpisodeType = readString(ITUNES_EPISODE_TYPE)
-                ITUNES_BLOCK -> iTunesBlock = readString(ITUNES_BLOCK)?.convertYesNo()
+                ITUNES_BLOCK -> iTunesBlock = readString(ITUNES_BLOCK)?.toBoolOrNull()
 
                 GOOGLE_DESCRIPTION -> googleDescription = readString(GOOGLE_DESCRIPTION)
-                GOOGLE_EXPLICIT -> googleExplicit = readString(GOOGLE_EXPLICIT)?.convertYesNo()
-                GOOGLE_BLOCK -> googleBlock = readString(GOOGLE_BLOCK)?.convertYesNo()
+                GOOGLE_EXPLICIT -> googleExplicit = readString(GOOGLE_EXPLICIT)?.toBoolOrNull()
+                GOOGLE_BLOCK -> googleBlock = readString(GOOGLE_BLOCK)?.toBoolOrNull()
                 else -> skip()
             }
         }
@@ -469,6 +469,7 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
     private fun Image?.replaceInvalidUrlByPriority(vararg priorityHref: String?): Image? {
         if (this == null || url != null) return this
         val href = priorityHref.firstOrNull { null != it } ?: return this
+
         return Image(
             link = link,
             title = title,
@@ -481,6 +482,7 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
 
     private fun hrefToImage(href: String?): Image? {
         href ?: return null
+
         return Image(
             link = null,
             title = null,

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
@@ -467,11 +467,12 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
     }
 
     private fun Image?.replaceInvalidUrlByPriority(vararg priorityHref: String?): Image? {
-        if (this == null || priorityHref.isNullOrEmpty() || url != null) return this
+        if (this == null || url != null) return this
+        val href = priorityHref.firstOrNull { null != it } ?: return this
         return Image(
             link = link,
             title = title,
-            url = priorityHref.find { it != null },
+            url = href,
             description = description,
             height = height,
             width = width

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/AutoMixParser.kt
@@ -19,7 +19,19 @@ package tw.ktrssreader.parser
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
 import tw.ktrssreader.constant.ParserConst
-import tw.ktrssreader.constant.ParserConst.CHANNEL
+import tw.ktrssreader.constant.ParserConst.AUTHOR
+import tw.ktrssreader.constant.ParserConst.BLOCK
+import tw.ktrssreader.constant.ParserConst.CATEGORY
+import tw.ktrssreader.constant.ParserConst.CLOUD
+import tw.ktrssreader.constant.ParserConst.COMMENTS
+import tw.ktrssreader.constant.ParserConst.COPYRIGHT
+import tw.ktrssreader.constant.ParserConst.DESCRIPTION
+import tw.ktrssreader.constant.ParserConst.DOCS
+import tw.ktrssreader.constant.ParserConst.DOMAIN
+import tw.ktrssreader.constant.ParserConst.EMAIL
+import tw.ktrssreader.constant.ParserConst.ENCLOSURE
+import tw.ktrssreader.constant.ParserConst.EXPLICIT
+import tw.ktrssreader.constant.ParserConst.GENERATOR
 import tw.ktrssreader.constant.ParserConst.GOOGLE_AUTHOR
 import tw.ktrssreader.constant.ParserConst.GOOGLE_BLOCK
 import tw.ktrssreader.constant.ParserConst.GOOGLE_CATEGORY
@@ -28,6 +40,10 @@ import tw.ktrssreader.constant.ParserConst.GOOGLE_EMAIL
 import tw.ktrssreader.constant.ParserConst.GOOGLE_EXPLICIT
 import tw.ktrssreader.constant.ParserConst.GOOGLE_IMAGE
 import tw.ktrssreader.constant.ParserConst.GOOGLE_OWNER
+import tw.ktrssreader.constant.ParserConst.GUID
+import tw.ktrssreader.constant.ParserConst.HEIGHT
+import tw.ktrssreader.constant.ParserConst.HREF
+import tw.ktrssreader.constant.ParserConst.IMAGE
 import tw.ktrssreader.constant.ParserConst.ITEM
 import tw.ktrssreader.constant.ParserConst.ITUNES_AUTHOR
 import tw.ktrssreader.constant.ParserConst.ITUNES_BLOCK
@@ -45,158 +61,294 @@ import tw.ktrssreader.constant.ParserConst.ITUNES_OWNER
 import tw.ktrssreader.constant.ParserConst.ITUNES_SEASON
 import tw.ktrssreader.constant.ParserConst.ITUNES_TITLE
 import tw.ktrssreader.constant.ParserConst.ITUNES_TYPE
-import tw.ktrssreader.model.channel.AutoMixChannelData
-import tw.ktrssreader.model.channel.Image
-import tw.ktrssreader.model.channel.Owner
-import tw.ktrssreader.model.channel.RssStandardChannelData
-import tw.ktrssreader.model.item.AutoMixItem
-import tw.ktrssreader.model.item.AutoMixItemData
-import tw.ktrssreader.model.item.Category
-import tw.ktrssreader.model.item.RssStandardItemData
+import tw.ktrssreader.constant.ParserConst.LANGUAGE
+import tw.ktrssreader.constant.ParserConst.LAST_BUILD_DATE
+import tw.ktrssreader.constant.ParserConst.LINK
+import tw.ktrssreader.constant.ParserConst.MANAGING_EDITOR
+import tw.ktrssreader.constant.ParserConst.OWNER
+import tw.ktrssreader.constant.ParserConst.PUB_DATE
+import tw.ktrssreader.constant.ParserConst.RATING
+import tw.ktrssreader.constant.ParserConst.SKIP_DAYS
+import tw.ktrssreader.constant.ParserConst.SKIP_HOURS
+import tw.ktrssreader.constant.ParserConst.SOURCE
+import tw.ktrssreader.constant.ParserConst.TEXT
+import tw.ktrssreader.constant.ParserConst.TEXT_INPUT
+import tw.ktrssreader.constant.ParserConst.TITLE
+import tw.ktrssreader.constant.ParserConst.TTL
+import tw.ktrssreader.constant.ParserConst.TYPE
+import tw.ktrssreader.constant.ParserConst.URL
+import tw.ktrssreader.constant.ParserConst.WEB_MASTER
+import tw.ktrssreader.constant.ParserConst.WIDTH
+import tw.ktrssreader.model.channel.*
+import tw.ktrssreader.model.item.*
 import tw.ktrssreader.utils.logD
 import java.io.IOException
 
-
 class AutoMixParser : ParserBase<AutoMixChannelData>() {
 
-    override val logTag: String = AutoMixParser::class.java.simpleName
+    private val rssStandardMap = HashMap<String, Any?>(19)
+    private val iTunesMap = HashMap<String, Any?>(11)
+    private val googlePlayMap = HashMap<String, Any?>(8)
 
-    override fun parse(xml: String) = parseAutoMixChannel(xml)
+    override val logTag: String = this::class.java.simpleName
+
+    override fun parse(xml: String): AutoMixChannelData {
+        parseTag(xml)
+
+        return AutoMixChannelData(
+            title = priorityMapValueOf(TITLE),
+            description = priorityMapValueOf(DESCRIPTION),
+            image = priorityMapValueOf(IMAGE),
+            language = priorityMapValueOf(LANGUAGE),
+            categories = priorityMapValueOf(CATEGORY),
+            link = priorityMapValueOf(LINK),
+            copyright = priorityMapValueOf(COPYRIGHT),
+            managingEditor = priorityMapValueOf(MANAGING_EDITOR),
+            webMaster = priorityMapValueOf(WEB_MASTER),
+            pubDate = priorityMapValueOf(PUB_DATE),
+            lastBuildDate = priorityMapValueOf(LAST_BUILD_DATE),
+            generator = priorityMapValueOf(GENERATOR),
+            docs = priorityMapValueOf(DOCS),
+            cloud = priorityMapValueOf(CLOUD),
+            ttl = priorityMapValueOf(TTL),
+            rating = priorityMapValueOf(RATING),
+            textInput = priorityMapValueOf(TEXT_INPUT),
+            skipHours = priorityMapValueOf(SKIP_HOURS),
+            skipDays = priorityMapValueOf(SKIP_DAYS),
+            items = priorityMapValueOf(ITEM),
+            simpleTitle = priorityMapValueOf(ITUNES_TITLE),
+            explicit = priorityMapValueOf(EXPLICIT),
+            email = priorityMapValueOf(EMAIL),
+            author = priorityMapValueOf(AUTHOR),
+            owner = priorityMapValueOf(OWNER),
+            type = priorityMapValueOf(TYPE),
+            newFeedUrl = priorityMapValueOf(ITUNES_NEW_FEED_URL),
+            block = priorityMapValueOf(BLOCK),
+            complete = priorityMapValueOf(ITUNES_COMPLETE),
+        )
+    }
 
     /**
      * The priority of reading tags as the following sequence:
      * RssStandard -> iTunes -> GooglePlay
      */
-    @Throws(IOException::class, XmlPullParserException::class)
-    private fun parseAutoMixChannel(xml: String): AutoMixChannelData {
-        val standardChannel = parseStandardChannel(xml)
-        return readAutoMixChannel(xml, standardChannel)
+    private fun <R> priorityMapValueOf(key: String): R? {
+        @Suppress("UNCHECKED_CAST")
+        return (rssStandardMap[key] ?: iTunesMap[key] ?: googlePlayMap[key]) as? R
     }
 
-    @Throws(IOException::class, XmlPullParserException::class)
-    private fun readAutoMixChannel(
-        xml: String,
-        standardChannel: RssStandardChannelData
-    ): AutoMixChannelData {
-        val fromITunes = parseChannel(xml) { readITunesTags(standardChannel) }
-        return parseChannel(xml) { readGoogleTags(fromITunes) }
-    }
+    private fun parseTag(xml: String) = parseChannel<Unit>(xml = xml) {
+        require(XmlPullParser.START_TAG, null, ParserConst.CHANNEL)
 
-    @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readITunesTags(standardChannel: RssStandardChannelData): AutoMixChannelData {
-        require(XmlPullParser.START_TAG, null, CHANNEL)
-        logD(logTag, "[readITunesTags]: Reading iTunes channel")
-        var image: Image? = standardChannel.image
-        var explicit: Boolean? = null
-        var categories: List<Category>? = standardChannel.categories
-        var author: String? = null
-        var owner: Owner? = null
-        var simpleTitle: String? = null
-        var type: String? = null
-        var newFeedUrl: String? = null
-        var block: Boolean? = null
-        var complete: Boolean? = null
-        val items: MutableList<AutoMixItemData> = mutableListOf()
-        var itemIndex = 0
-
-        while (next() != XmlPullParser.END_TAG) {
-            if (eventType != XmlPullParser.START_TAG) continue
-
-            when (name) {
-                ITUNES_IMAGE -> image = readImage(standardChannel.image, ITUNES_IMAGE)
-                ITUNES_EXPLICIT -> explicit = readString(ITUNES_EXPLICIT)?.toBoolean()
-                ITUNES_CATEGORY -> categories.doActionOrSkip(this) { categories = readCategory(ITUNES_CATEGORY) }
-                ITUNES_AUTHOR -> author = readString(ITUNES_AUTHOR)
-                ITUNES_OWNER -> owner = readITunesOwner()
-                ITUNES_TITLE -> simpleTitle = readString(ITUNES_TITLE)
-                ITUNES_TYPE -> type = readString(ITUNES_TYPE)
-                ITUNES_NEW_FEED_URL -> newFeedUrl = readString(ITUNES_NEW_FEED_URL)
-                ITUNES_BLOCK -> block = readString(ITUNES_BLOCK)?.convertYesNo()
-                ITUNES_COMPLETE -> complete = readString(ITUNES_COMPLETE)?.convertYesNo()
-                ITEM -> {
-                    standardChannel.items?.get(itemIndex)?.let {
-                        items.add(readITunesItem(it))
-                        itemIndex++
-                    }
-                }
-                else -> skip()
-            }
-        }
-
-        require(XmlPullParser.END_TAG, null, CHANNEL)
-        return AutoMixChannelData(
-            title = standardChannel.title,
-            description = standardChannel.description,
-            image = image,
-            language = standardChannel.language,
-            categories = categories,
-            link = standardChannel.link,
-            copyright = standardChannel.copyright,
-            managingEditor = standardChannel.managingEditor,
-            webMaster = standardChannel.webMaster,
-            pubDate = standardChannel.pubDate,
-            lastBuildDate = standardChannel.lastBuildDate,
-            generator = standardChannel.generator,
-            docs = standardChannel.docs,
-            cloud = standardChannel.cloud,
-            ttl = standardChannel.ttl,
-            rating = standardChannel.rating,
-            textInput = standardChannel.textInput,
-            skipHours = standardChannel.skipHours,
-            skipDays = standardChannel.skipDays,
-            items = items.takeIf { it.isNotEmpty() },
-            simpleTitle = simpleTitle,
-            explicit = explicit,
-            email = null,
-            author = author,
-            owner = owner,
-            type = type,
-            newFeedUrl = newFeedUrl,
-            block = block,
-            complete = complete
-        )
-    }
-
-    @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readImage(standardImage: Image?, tagName: String): Image {
-        require(XmlPullParser.START_TAG, null, tagName)
-        val href: String? = getAttributeValue(null, ParserConst.HREF)
-        if (next() == XmlPullParser.TEXT) {
-            nextTag()
-        }
-        require(XmlPullParser.END_TAG, null, tagName)
-        logD(logTag, "[readImage]: link = ${standardImage?.link}, title = ${standardImage?.title}, url = ${standardImage?.url ?: href}, description = ${standardImage?.description}, height = ${standardImage?.height}, width = ${standardImage?.width}")
-        return Image(
-            link = standardImage?.link,
-            title = standardImage?.title,
-            url = standardImage?.url ?: href,
-            description = standardImage?.description,
-            height = standardImage?.height,
-            width = standardImage?.width
-        )
-    }
-
-    @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readCategory(tagName: String): List<Category>? {
-        require(XmlPullParser.START_TAG, null, tagName)
+        var title: String? = null
+        var description: String? = null
+        var image: Image? = null
+        var language: String? = null
         val categories = mutableListOf<Category>()
-        getAttributeValue(null, ParserConst.TEXT)?.let { categories.add(Category(name = it, null)) }
+        var link: String? = null
+        var copyright: String? = null
+        var managingEditor: String? = null
+        var webMaster: String? = null
+        var pubDate: String? = null
+        var lastBuildDate: String? = null
+        var generator: String? = null
+        var docs: String? = null
+        var cloud: Cloud? = null
+        var ttl: Int? = null
+        var rating: String? = null
+        var textInput: TextInput? = null
+        var skipHours: List<Int>? = null
+        var skipDays: List<String>? = null
+        val items = mutableListOf<AutoMixItemData>()
+
+        var iTunesImageHref: String? = null
+        val iTunesCategories = mutableListOf<Category>()
+        var iTunesSimpleTitle: String? = null
+        var iTunesExplicit: Boolean? = null
+        var iTunesEmail: String? = null
+        var iTunesAuthor: String? = null
+        var iTunesOwner: Owner? = null
+        var iTunesType: String? = null
+        var iTunesNewFeedUrl: String? = null
+        var iTunesBlock: Boolean? = null
+        var iTunesComplete: Boolean? = null
+
+        var googleDescription: String? = null
+        var googleImageHref: String? = null
+        val googleCategories = mutableListOf<Category?>()
+        var googleExplicit: Boolean? = null
+        var googleEmail: String? = null
+        var googleAuthor: String? = null
+        var googleOwner: Owner? = null
+        var googleBlock: Boolean? = null
+
         while (next() != XmlPullParser.END_TAG) {
             if (eventType != XmlPullParser.START_TAG) continue
 
             when (name) {
-                tagName -> {
-                    getAttributeValue(null, ParserConst.TEXT)
-                        ?.let { categories.add(Category(name = it, domain = null)) }
-                    nextTag()
-                }
+                TITLE -> title = readString(TITLE)
+                DESCRIPTION -> description = readString(DESCRIPTION)
+                LINK -> link = readString(LINK)
+                IMAGE -> image = readImage()
+                LANGUAGE -> language = readString(LANGUAGE)
+                CATEGORY -> readCategory(CATEGORY)?.let { categories.add(it) }
+                COPYRIGHT -> copyright = readString(COPYRIGHT)
+                MANAGING_EDITOR -> managingEditor = readString(MANAGING_EDITOR)
+                WEB_MASTER -> webMaster = readString(WEB_MASTER)
+                PUB_DATE -> pubDate = readString(PUB_DATE)
+                LAST_BUILD_DATE -> lastBuildDate = readString(LAST_BUILD_DATE)
+                GENERATOR -> generator = readString(GENERATOR)
+                DOCS -> docs = readString(DOCS)
+                CLOUD -> cloud = readCloud()
+                TTL -> ttl = readString(TTL)?.toIntOrNull()
+                RATING -> rating = readString(RATING)
+                TEXT_INPUT -> textInput = readTextInput()
+                SKIP_HOURS -> skipHours = readSkipHours()
+                SKIP_DAYS -> skipDays = readSkipDays()
+                ITEM -> items.add(readItem())
+
+                ITUNES_IMAGE -> iTunesImageHref = readImageHref(ITUNES_IMAGE)
+                ITUNES_CATEGORY -> readCategory(ITUNES_CATEGORY)?.let { iTunesCategories.add(it) }
+                ITUNES_TITLE -> iTunesSimpleTitle = readString(ITUNES_TITLE)
+                ITUNES_EXPLICIT -> iTunesExplicit = readString(ITUNES_EXPLICIT)?.convertYesNo()
+                ITUNES_EMAIL -> iTunesEmail = readString(ITUNES_EMAIL)
+                ITUNES_AUTHOR -> iTunesAuthor = readString(ITUNES_AUTHOR)
+                ITUNES_OWNER -> iTunesOwner = readITunesOwner()
+                ITUNES_TYPE -> iTunesType = readString(ITUNES_TYPE)
+                ITUNES_NEW_FEED_URL -> iTunesNewFeedUrl = readString(ITUNES_NEW_FEED_URL)
+                ITUNES_BLOCK -> iTunesBlock = readString(ITUNES_BLOCK)?.convertYesNo()
+                ITUNES_COMPLETE -> iTunesComplete = readString(ITUNES_COMPLETE)?.convertYesNo()
+
+                GOOGLE_DESCRIPTION -> googleDescription = readString(GOOGLE_DESCRIPTION)
+                GOOGLE_IMAGE -> googleImageHref = readImageHref(GOOGLE_IMAGE)
+                GOOGLE_CATEGORY -> googleCategories.add(readCategory(GOOGLE_CATEGORY))
+                GOOGLE_EXPLICIT -> googleExplicit = readString(GOOGLE_EXPLICIT)?.convertYesNo()
+                GOOGLE_EMAIL -> googleEmail = readString(GOOGLE_EMAIL)
+                GOOGLE_AUTHOR -> googleAuthor = readString(GOOGLE_AUTHOR)
+                GOOGLE_OWNER -> googleOwner = readGoogleOwner()
+                GOOGLE_BLOCK -> googleBlock = readString(GOOGLE_BLOCK)?.convertYesNo()
+
                 else -> skip()
             }
         }
-        logD(logTag, "[readCategory]: categories = $categories")
-        require(XmlPullParser.END_TAG, null, tagName)
-        return categories
+        require(XmlPullParser.END_TAG, null, ParserConst.CHANNEL)
+
+        rssStandardMap.run {
+            put(TITLE, title)
+            put(DESCRIPTION, description)
+            put(IMAGE, image.replaceInvalidUrlByPriority(iTunesImageHref, googleImageHref))
+            put(LANGUAGE, language)
+            put(CATEGORY, categories.takeIf { it.isNotEmpty() })
+            put(LINK, link)
+            put(COPYRIGHT, copyright)
+            put(MANAGING_EDITOR, managingEditor)
+            put(WEB_MASTER, webMaster)
+            put(PUB_DATE, pubDate)
+            put(LAST_BUILD_DATE, lastBuildDate)
+            put(GENERATOR, generator)
+            put(DOCS, docs)
+            put(CLOUD, cloud)
+            put(TTL, ttl)
+            put(RATING, rating)
+            put(TEXT_INPUT, textInput)
+            put(SKIP_HOURS, skipHours)
+            put(SKIP_DAYS, skipDays)
+            put(ITEM, items.takeIf { it.isNotEmpty() })
+        }
+        iTunesMap.run {
+            put(IMAGE, hrefToImage(iTunesImageHref))
+            put(CATEGORY, iTunesCategories.takeIf { it.isNotEmpty() })
+            put(ITUNES_TITLE, iTunesSimpleTitle)
+            put(EXPLICIT, iTunesExplicit)
+            put(EMAIL, iTunesEmail)
+            put(AUTHOR, iTunesAuthor)
+            put(OWNER, iTunesOwner)
+            put(TYPE, iTunesType)
+            put(ITUNES_NEW_FEED_URL, iTunesNewFeedUrl)
+            put(BLOCK, iTunesBlock)
+            put(ITUNES_COMPLETE, iTunesComplete)
+        }
+        googlePlayMap.run {
+            put(DESCRIPTION, googleDescription)
+            put(IMAGE, hrefToImage(googleImageHref))
+            put(CATEGORY, googleCategories.takeIf { it.isNotEmpty() })
+            put(EXPLICIT, googleExplicit)
+            put(EMAIL, googleEmail)
+            put(AUTHOR, googleAuthor)
+            put(OWNER, googleOwner)
+            put(BLOCK, googleBlock)
+        }
     }
+
+    @Throws(IOException::class, XmlPullParserException::class)
+    private fun XmlPullParser.readImage(): Image? {
+        require(XmlPullParser.START_TAG, null, IMAGE)
+        var link: String? = null
+        var title: String? = null
+        var url: String? = null
+        var description: String? = null
+        var height: Int? = null
+        var width: Int? = null
+        while (next() != XmlPullParser.END_TAG) {
+            if (eventType != XmlPullParser.START_TAG) continue
+
+            logD(logTag, "[readImage]: RSS 2.0 tag name = $name.")
+            when (name) {
+                LINK -> link = readString(LINK)
+                TITLE -> title = readString(TITLE)
+                URL -> url = readString(URL)
+                DESCRIPTION -> description = readString(DESCRIPTION)
+                HEIGHT -> height = readString(HEIGHT)?.toIntOrNull()
+                WIDTH -> width = readString(WIDTH)?.toIntOrNull()
+                else -> skip()
+            }
+        }
+        require(XmlPullParser.END_TAG, null, IMAGE)
+        return Image(
+            link = link,
+            title = title,
+            url = url,
+            description = description,
+            height = height,
+            width = width
+        ).takeIf {
+            it.link != null || it.title != null || it.url != null
+                    || it.description != null || it.height != null || it.width != null
+        }
+    }
+
+    @Throws(IOException::class, XmlPullParserException::class)
+    private fun XmlPullParser.readImageHref(tagName: String): String? {
+        var href: String? = null
+        readAttributes(tagName, listOf(HREF)) { attr, value ->
+            if (attr == HREF) href = value
+        }
+        return href
+    }
+
+    @Throws(IOException::class, XmlPullParserException::class)
+    private fun XmlPullParser.readCategory(tagName: String): Category? {
+        when (tagName) {
+            ITUNES_CATEGORY, GOOGLE_CATEGORY -> {
+                var text: String? = null
+                readAttributes(tagName, listOf(TEXT)) { attr, value ->
+                    if (attr == TEXT) text = value
+                }
+                text ?: return null
+                return Category(name = text, domain = null)
+            }
+            CATEGORY -> {
+                require(XmlPullParser.START_TAG, null, CATEGORY)
+                val domain: String? = getAttributeValue(null, DOMAIN)
+                val name: String? = readString(tagName = CATEGORY)
+                require(XmlPullParser.END_TAG, null, CATEGORY)
+                logD(logTag, "[readCategory]: name = $name, domain = $domain")
+                return if (name == null && domain == null) null else Category(name = name, domain = domain)
+            }
+            else -> return null
+        }
+    }
+
 
     @Throws(IOException::class, XmlPullParserException::class)
     private fun XmlPullParser.readITunesOwner(): Owner {
@@ -213,188 +365,111 @@ class AutoMixParser : ParserBase<AutoMixChannelData>() {
             }
         }
         require(XmlPullParser.END_TAG, null, ITUNES_OWNER)
-        logD(logTag, "[readITunesOwner]: name = $name, email = $email")
+        logD(logTag, "[readOwner] name = $name, email = $email")
         return Owner(name = name, email = email)
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readITunesItem(standardItem: RssStandardItemData): AutoMixItemData {
-        require(XmlPullParser.START_TAG, null, ITEM)
-        logD(logTag, "[readITunesItem]: Reading iTunes item")
-        var simpleTitle: String? = null
-        var duration: String? = null
-        var image: String? = null
-        var explicit: Boolean? = null
-        var episode: Int? = null
-        var season: Int? = null
-        var episodeType: String? = null
-        var block: Boolean? = null
-        var author: String? = standardItem.author
-        while (next() != XmlPullParser.END_TAG) {
-            if (eventType != XmlPullParser.START_TAG) continue
-
-            when (name) {
-                ITUNES_DURATION -> duration = readString(ITUNES_DURATION)
-                ITUNES_IMAGE -> image = readImage(null, ITUNES_IMAGE).url
-                ITUNES_EXPLICIT -> explicit = readString(ITUNES_EXPLICIT)?.toBoolean()
-                ITUNES_TITLE -> simpleTitle = readString(ITUNES_TITLE)
-                ITUNES_EPISODE -> episode = readString(ITUNES_EPISODE)?.toIntOrNull()
-                ITUNES_SEASON -> season = readString(ITUNES_SEASON)?.toIntOrNull()
-                ITUNES_EPISODE_TYPE -> episodeType = readString(ITUNES_EPISODE_TYPE)
-                ITUNES_BLOCK -> block = readString(ITUNES_BLOCK)?.convertYesNo()
-                ITUNES_AUTHOR -> author.doActionOrSkip(this) { author = readString(ITUNES_AUTHOR) }
-                else -> skip()
-            }
-        }
-        require(XmlPullParser.END_TAG, null, ITEM)
-        return AutoMixItemData(
-            title = standardItem.title,
-            enclosure = standardItem.enclosure,
-            guid = standardItem.guid,
-            pubDate = standardItem.pubDate,
-            description = standardItem.description,
-            link = standardItem.link,
-            author = author,
-            categories = standardItem.categories,
-            comments = standardItem.comments,
-            source = standardItem.source,
-            simpleTitle = simpleTitle,
-            duration = duration,
-            image = image,
-            explicit = explicit,
-            episode = episode,
-            season = season,
-            episodeType = episodeType,
-            block = block
-        )
-    }
-
-    @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readGoogleTags(previousResult: AutoMixChannelData): AutoMixChannelData {
-        require(XmlPullParser.START_TAG, null, CHANNEL)
-        logD(logTag, "[readGoogleTags] Reading Google Play channel")
-        var description: String? = previousResult.description
-        var image: Image? = previousResult.image
-        var explicit: Boolean? = previousResult.explicit
-        var categories: List<Category>? = previousResult.categories
-        var author: String? = previousResult.author
-        var owner: Owner? = previousResult.owner
-        var block: Boolean? = previousResult.block
-        var email: String? = previousResult.email
-        val items: MutableList<AutoMixItem> = mutableListOf()
-        var itemIndex = 0
-        while (next() != XmlPullParser.END_TAG) {
-            if (eventType != XmlPullParser.START_TAG) continue
-
-            when (name) {
-                GOOGLE_DESCRIPTION -> description.doActionOrSkip(this) { description = readString(GOOGLE_DESCRIPTION) }
-                GOOGLE_IMAGE -> image = readImage(previousResult.image, GOOGLE_IMAGE)
-                GOOGLE_EXPLICIT -> explicit.doActionOrSkip(this) { explicit = readString(GOOGLE_EXPLICIT)?.convertYesNo() }
-                GOOGLE_CATEGORY -> categories.doActionOrSkip(this) { categories = readCategory(GOOGLE_CATEGORY) }
-                GOOGLE_AUTHOR -> author.doActionOrSkip(this) { author = readString(GOOGLE_AUTHOR) }
-                GOOGLE_OWNER -> owner = readGoogleOwner(previousResult.owner)
-                GOOGLE_BLOCK -> block.doActionOrSkip(this) { block = readString(GOOGLE_BLOCK)?.convertYesNo() }
-                GOOGLE_EMAIL -> email.doActionOrSkip(this) { email = readString(GOOGLE_EMAIL) }
-                ITEM -> {
-                    previousResult.items?.get(itemIndex)?.let {
-                        items.add(readGoogleItem(it))
-                        itemIndex++
-                    }
-                }
-                else -> skip()
-            }
-        }
-        require(XmlPullParser.END_TAG, null, CHANNEL)
-        return AutoMixChannelData(
-            title = previousResult.title,
-            description = description,
-            image = image,
-            language = previousResult.language,
-            categories = categories?.takeIf { it.isNotEmpty() },
-            link = previousResult.link,
-            copyright = previousResult.copyright,
-            managingEditor = previousResult.managingEditor,
-            webMaster = previousResult.webMaster,
-            pubDate = previousResult.pubDate,
-            lastBuildDate = previousResult.lastBuildDate,
-            generator = previousResult.generator,
-            docs = previousResult.docs,
-            cloud = previousResult.cloud,
-            ttl = previousResult.ttl,
-            rating = previousResult.rating,
-            textInput = previousResult.textInput,
-            skipHours = previousResult.skipHours,
-            skipDays = previousResult.skipDays,
-            items = items.takeIf { it.isNotEmpty() },
-            simpleTitle = previousResult.simpleTitle,
-            explicit = explicit,
-            email = email,
-            author = author,
-            owner = owner,
-            type = previousResult.type,
-            newFeedUrl = previousResult.newFeedUrl,
-            block = block,
-            complete = previousResult.complete
-        )
-    }
-
-    @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readGoogleOwner(previousResult: Owner?): Owner? {
-        val owner = if (previousResult?.email?.isNotEmpty() == true) {
-            skip()
-            previousResult
-        } else {
-            Owner(name = previousResult?.name, email = readString(GOOGLE_OWNER))
-        }
+    private fun XmlPullParser.readGoogleOwner(): Owner? {
+        val email = readString(GOOGLE_OWNER) ?: return null
+        val owner = Owner(name = null, email = email)
         logD(logTag, "[readGoogleOwner]: $owner")
         return owner
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readGoogleItem(previousResult: AutoMixItem): AutoMixItem {
+    private fun XmlPullParser.readItem(): AutoMixItemData {
         require(XmlPullParser.START_TAG, null, ITEM)
-        logD(logTag, "[readGoogleItem]: Reading Google Play item")
-        var description: String? = previousResult.description
-        var explicit: Boolean? = previousResult.explicit
-        var block: Boolean? = previousResult.block
+        var title: String? = null
+        var enclosure: Enclosure? = null
+        var guid: Guid? = null
+        var pubDate: String? = null
+        var description: String? = null
+        var link: String? = null
+        var author: String? = null
+        val categories = mutableListOf<Category>()
+        var comments: String? = null
+        var source: Source? = null
+
+        var iTunesAuthor: String? = null
+        var iTunesSimpleTitle: String? = null
+        var iTunesDuration: String? = null
+        var iTunesImageHref: String? = null
+        var iTunesExplicit: Boolean? = null
+        var iTunesEpisode: Int? = null
+        var iTunesSeason: Int? = null
+        var iTunesEpisodeType: String? = null
+        var iTunesBlock: Boolean? = null
+
+        var googleDescription: String? = null
+        var googleExplicit: Boolean? = null
+        var googleBlock: Boolean? = null
+
         while (next() != XmlPullParser.END_TAG) {
             if (eventType != XmlPullParser.START_TAG) continue
 
-            when (name) {
-                GOOGLE_DESCRIPTION -> description.doActionOrSkip(this) { description = readString(GOOGLE_DESCRIPTION) }
-                GOOGLE_EXPLICIT -> explicit.doActionOrSkip(this) { explicit = readString(GOOGLE_EXPLICIT)?.convertYesNo() }
-                GOOGLE_BLOCK -> block.doActionOrSkip(this) { block = readString(GOOGLE_BLOCK)?.convertYesNo() }
+            logD(logTag, "[readRssStandardItem] Reading tag name $name.")
+            when (this.name) {
+                TITLE -> title = readString(TITLE)
+                ENCLOSURE -> enclosure = readEnclosure()
+                GUID -> guid = readGuid()
+                PUB_DATE -> pubDate = readString(PUB_DATE)
+                DESCRIPTION -> description = readString(DESCRIPTION)
+                LINK -> link = readString(LINK)
+                AUTHOR -> author = readString(AUTHOR)
+                CATEGORY -> readCategory(CATEGORY)?.let { categories.add(it) }
+                COMMENTS -> comments = readString(COMMENTS)
+                SOURCE -> source = readSource()
+
+                ITUNES_AUTHOR -> iTunesAuthor = readString(ITUNES_AUTHOR)
+                ITUNES_TITLE -> iTunesSimpleTitle = readString(ITUNES_TITLE)
+                ITUNES_DURATION -> iTunesDuration = readString(ITUNES_DURATION)
+                ITUNES_IMAGE -> iTunesImageHref = readImageHref(ITUNES_IMAGE)
+                ITUNES_EXPLICIT -> iTunesExplicit = readString(ITUNES_EXPLICIT)?.convertYesNo()
+                ITUNES_EPISODE -> iTunesEpisode = readString(ITUNES_EPISODE)?.toIntOrNull()
+                ITUNES_SEASON -> iTunesSeason = readString(ITUNES_SEASON)?.toIntOrNull()
+                ITUNES_EPISODE_TYPE -> iTunesEpisodeType = readString(ITUNES_EPISODE_TYPE)
+                ITUNES_BLOCK -> iTunesBlock = readString(ITUNES_BLOCK)?.convertYesNo()
+
+                GOOGLE_DESCRIPTION -> googleDescription = readString(GOOGLE_DESCRIPTION)
+                GOOGLE_EXPLICIT -> googleExplicit = readString(GOOGLE_EXPLICIT)?.convertYesNo()
+                GOOGLE_BLOCK -> googleBlock = readString(GOOGLE_BLOCK)?.convertYesNo()
                 else -> skip()
             }
         }
         require(XmlPullParser.END_TAG, null, ITEM)
+
         return AutoMixItemData(
-            title = previousResult.title,
-            enclosure = previousResult.enclosure,
-            guid = previousResult.guid,
-            pubDate = previousResult.pubDate,
-            description = description,
-            link = previousResult.link,
-            author = previousResult.author,
-            categories = previousResult.categories,
-            comments = previousResult.comments,
-            source = previousResult.source,
-            simpleTitle = previousResult.simpleTitle,
-            duration = previousResult.duration,
-            image = previousResult.image,
-            explicit = explicit,
-            episode = previousResult.episode,
-            season = previousResult.season,
-            episodeType = previousResult.episodeType,
-            block = block
+            title = title,
+            enclosure = enclosure,
+            guid = guid,
+            pubDate = pubDate,
+            description = description ?: googleDescription,
+            link = link,
+            author = author ?: iTunesAuthor,
+            categories = categories.takeIf { it.isNotEmpty() },
+            comments = comments,
+            source = source,
+            simpleTitle = iTunesSimpleTitle,
+            duration = iTunesDuration,
+            image = iTunesImageHref,
+            explicit = iTunesExplicit ?: googleExplicit,
+            episode = iTunesEpisode,
+            season = iTunesSeason,
+            episodeType = iTunesEpisodeType,
+            block = iTunesBlock ?: googleBlock
         )
     }
 
-    private inline fun Any?.doActionOrSkip(parser: XmlPullParser, action: () -> Unit) {
-        return if (this == null) {
-            action()
-        } else {
-            parser.skip()
-        }
+    private fun Image?.replaceInvalidUrlByPriority(vararg priorityHref: String?): Image? {
+        if (this == null) return null
+        if (priorityHref.isNullOrEmpty() || url != null) return this
+
+        return Image(link = link, title = title, url = priorityHref.find { it != null }, description = description, height = height, width = width)
+    }
+
+    private fun hrefToImage(href: String?): Image? {
+        href ?: return null
+        return Image(link = null, title = null, url = href, description = null, height = null, width = null)
     }
 }

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/GoogleParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/GoogleParser.kt
@@ -70,11 +70,11 @@ class GoogleParser : ParserBase<GoogleChannelData>() {
             when (name) {
                 GOOGLE_DESCRIPTION -> description = readString(GOOGLE_DESCRIPTION)
                 GOOGLE_IMAGE -> image = readImage()
-                GOOGLE_EXPLICIT -> explicit = readString(GOOGLE_EXPLICIT)?.convertYesNo()
+                GOOGLE_EXPLICIT -> explicit = readString(GOOGLE_EXPLICIT)?.toBoolOrNull()
                 GOOGLE_CATEGORY -> categories = readCategory()
                 GOOGLE_AUTHOR -> author = readString(GOOGLE_AUTHOR)
                 GOOGLE_OWNER -> owner = Owner(name = null, email = readString(GOOGLE_OWNER))
-                GOOGLE_BLOCK -> block = readString(GOOGLE_BLOCK)?.convertYesNo()
+                GOOGLE_BLOCK -> block = readString(GOOGLE_BLOCK)?.toBoolOrNull()
                 GOOGLE_EMAIL -> email = readString(GOOGLE_EMAIL)
                 ITEM -> {
                     standardChannel.items?.get(itemIndex)?.let {
@@ -127,8 +127,8 @@ class GoogleParser : ParserBase<GoogleChannelData>() {
 
             when (name) {
                 GOOGLE_DESCRIPTION -> description = readString(GOOGLE_DESCRIPTION)
-                GOOGLE_EXPLICIT -> explicit = readString(GOOGLE_EXPLICIT)?.convertYesNo()
-                GOOGLE_BLOCK -> block = readString(GOOGLE_BLOCK)?.convertYesNo()
+                GOOGLE_EXPLICIT -> explicit = readString(GOOGLE_EXPLICIT)?.toBoolOrNull()
+                GOOGLE_BLOCK -> block = readString(GOOGLE_BLOCK)?.toBoolOrNull()
                 else -> skip()
             }
         }

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/ITunesParser.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/ITunesParser.kt
@@ -87,8 +87,8 @@ class ITunesParser : ParserBase<ITunesChannelData>() {
                 ITUNES_TITLE -> simpleTitle = readString(ITUNES_TITLE)
                 ITUNES_TYPE -> type = readString(ITUNES_TYPE)
                 ITUNES_NEW_FEED_URL -> newFeedUrl = readString(ITUNES_NEW_FEED_URL)
-                ITUNES_BLOCK -> block = readString(ITUNES_BLOCK)?.convertYesNo()
-                ITUNES_COMPLETE -> complete = readString(ITUNES_COMPLETE)?.convertYesNo()
+                ITUNES_BLOCK -> block = readString(ITUNES_BLOCK)?.toBoolOrNull()
+                ITUNES_COMPLETE -> complete = readString(ITUNES_COMPLETE)?.toBoolOrNull()
                 ITEM -> {
                     standardChannel.items?.get(itemIndex)?.let {
                         items.add(readItem(it))
@@ -214,7 +214,7 @@ class ITunesParser : ParserBase<ITunesChannelData>() {
                 ITUNES_EPISODE -> episode = readString(ITUNES_EPISODE)?.toIntOrNull()
                 ITUNES_SEASON -> season = readString(ITUNES_SEASON)?.toIntOrNull()
                 ITUNES_EPISODE_TYPE -> episodeType = readString(ITUNES_EPISODE_TYPE)
-                ITUNES_BLOCK -> block = readString(ITUNES_BLOCK)?.convertYesNo()
+                ITUNES_BLOCK -> block = readString(ITUNES_BLOCK)?.toBoolOrNull()
                 ITUNES_AUTHOR -> author = readString(ITUNES_AUTHOR)
                 else -> skip()
             }

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/ParserBase.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/ParserBase.kt
@@ -152,8 +152,8 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
 
     protected fun String.convertYesNo(): Boolean? {
         return when (toLowerCase()) {
-            "yes" -> true
-            "no" -> false
+            "yes", "true" -> true
+            "no", "false" -> false
             else -> null
         }
     }
@@ -316,7 +316,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readEnclosure(): Enclosure {
+    protected fun XmlPullParser.readEnclosure(): Enclosure {
         var url: String? = null
         var length: Long? = null
         var type: String? = null
@@ -341,7 +341,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readCloud(): Cloud {
+    protected fun XmlPullParser.readCloud(): Cloud {
         var domain: String? = null
         var port: Int? = null
         var path: String? = null
@@ -370,7 +370,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readTextInput(): TextInput {
+    protected fun XmlPullParser.readTextInput(): TextInput {
         require(XmlPullParser.START_TAG, null, TEXT_INPUT)
         var title: String? = null
         var description: String? = null
@@ -393,7 +393,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readSkipHours(): List<Int>? {
+    protected fun XmlPullParser.readSkipHours(): List<Int>? {
         require(XmlPullParser.START_TAG, null, SKIP_HOURS)
         val hours = mutableListOf<Int>()
         while (next() != XmlPullParser.END_TAG) {
@@ -411,7 +411,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readSkipDays(): List<String>? {
+    protected fun XmlPullParser.readSkipDays(): List<String>? {
         require(XmlPullParser.START_TAG, null, SKIP_DAYS)
         val days = mutableListOf<String>()
         while (next() != XmlPullParser.END_TAG) {
@@ -428,7 +428,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readGuid(): Guid {
+    protected fun XmlPullParser.readGuid(): Guid {
         require(XmlPullParser.START_TAG, null, GUID)
         val isPermaLink: Boolean? = getAttributeValue(null, PERMALINK)?.toBoolean()
         val value: String? = readString(GUID)
@@ -438,7 +438,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
     }
 
     @Throws(IOException::class, XmlPullParserException::class)
-    private fun XmlPullParser.readSource(): Source {
+    protected fun XmlPullParser.readSource(): Source {
         require(XmlPullParser.START_TAG, null, SOURCE)
         val url: String? = getAttributeValue(null, URL)
         val title: String? = readString(SOURCE)

--- a/ktRssReader/src/main/java/tw/ktrssreader/parser/ParserBase.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/parser/ParserBase.kt
@@ -150,7 +150,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
         logW(logTag, "[skip] tag name = $name, depth is $depth.")
     }
 
-    protected fun String.convertYesNo(): Boolean? {
+    protected fun String.toBoolOrNull(): Boolean? {
         return when (toLowerCase()) {
             "yes", "true" -> true
             "no", "false" -> false
@@ -359,7 +359,10 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
                 PROTOCOL -> protocol = value
             }
         }
-        logD(logTag, "[readCloud]: domain = $domain, port = $port, path = $path, registerProcedure = $registerProcedure, protocol = $protocol")
+        logD(
+            logTag,
+            "[readCloud]: domain = $domain, port = $port, path = $path, registerProcedure = $registerProcedure, protocol = $protocol"
+        )
         return Cloud(
             domain = domain,
             port = port,
@@ -388,7 +391,10 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
             }
         }
         require(XmlPullParser.END_TAG, null, TEXT_INPUT)
-        logD(logTag, "[readTextInput]: title = $title, description = $description, name = $name, link = $link")
+        logD(
+            logTag,
+            "[readTextInput]: title = $title, description = $description, name = $name, link = $link"
+        )
         return TextInput(title = title, description = description, name = name, link = link)
     }
 


### PR DESCRIPTION
Improve AutoMixParser performance

- 目前使用 hashmap 去紀錄每次讀到的值，最後再按照優先順序生成物件，而非解析三次 XML
- 修正 TAGS_MAPPING_TABLE 部分錯誤

測試 7kb的 xml 執行 10 次

測試結果 -> 平均可節省1倍時間

```
 1
 old parser took 35 ms
 new parser took 9 ms
 -------------------------
 2
 old parser took 17 ms
 new parser took 10 ms
 -------------------------
 3
 old parser took 10 ms
 new parser took 3 ms
 -------------------------
 4
 old parser took 6 ms
 new parser took 3 ms
 -------------------------
 5
 old parser took 4 ms
 new parser took 4 ms
 -------------------------
 6
 old parser took 5 ms
 new parser took 2 ms
 -------------------------
 7
 old parser took 6 ms
 new parser took 4 ms
 -------------------------
 8
 old parser took 6 ms
 new parser took 4 ms
 -------------------------
 9
 old parser took 3 ms
 new parser took 1 ms
 -------------------------
 10
 old parser took 2 ms
 new parser took 1 ms
 -------------------------
```
