### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then, add this dependency to the `build.gradle` file in app directory.
 
 ```gradle
 dependencies {
-  implemetation "com.github.ivanisidrowu:KtRssReader:v1.0.1"
+  implementation "com.github.ivanisidrowu:KtRssReader:v1.0.1"
 }
 ```
 


### PR DESCRIPTION
Bit silly, but there is a typo in `implementation` on the README file that messes up copy paste 😄 