### PR TITLE
Add @RssValue and standard generator tests.

### DIFF
--- a/annotation/src/main/java/tw/ktrssreader/annotation/Annotations.kt
+++ b/annotation/src/main/java/tw/ktrssreader/annotation/Annotations.kt
@@ -33,4 +33,8 @@ annotation class RssAttribute(val name: String = "")
 
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.SOURCE)
+annotation class RssValue
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.SOURCE)
 annotation class RssRawData(val rawTags: Array<String>)

--- a/processor/src/main/java/tw/ktrssreader/processor/RssAnnotationProcessor.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/RssAnnotationProcessor.kt
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService
 import tw.ktrssreader.annotation.RssAttribute
 import tw.ktrssreader.annotation.RssRawData
 import tw.ktrssreader.annotation.RssTag
+import tw.ktrssreader.annotation.RssValue
 import tw.ktrssreader.processor.const.CHANNEL
 import tw.ktrssreader.processor.generator.ExtensionGenerator
 import tw.ktrssreader.processor.generator.ParserGenerator
@@ -47,7 +48,8 @@ class RssAnnotationProcessor : AbstractProcessor() {
         return mutableSetOf(
             RssTag::class.java.canonicalName,
             RssRawData::class.java.canonicalName,
-            RssAttribute::class.java.canonicalName
+            RssAttribute::class.java.canonicalName,
+            RssValue::class.java.canonicalName
         )
     }
 

--- a/processor/src/main/java/tw/ktrssreader/processor/const/ParserConst.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/const/ParserConst.kt
@@ -21,6 +21,7 @@ const val PARSER_SUFFIX = "Parser"
 const val PARSER_FUNC_NAME = "parse"
 const val GENERATOR_PACKAGE = "tw.ktrssreader.generated"
 const val GET_PREFIX = "get"
+const val IS_PREFIX = "is"
 const val ANNOTATION_SIGN = "\$annotations"
 const val EXTENSION_NAME = "ParserExtensions"
 const val READER_NAME = "Reader"
@@ -38,3 +39,5 @@ const val METHOD_CO_READ = "coRead"
 
 const val ITUNES_PREFIX = "itunes"
 const val GOOGLE_PREFIX = "googleplay"
+
+const val TAB = '\t'

--- a/processor/src/main/java/tw/ktrssreader/processor/generator/ExtensionGenerator.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/generator/ExtensionGenerator.kt
@@ -49,11 +49,11 @@ class ExtensionGenerator(
                 """
                 |
                 |%1T(xml.toByteArray()).use { inputStream ->
-                |    return %2T.newPullParser().apply {
-                |        setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
-                |        setInput(inputStream, null)
-                |        nextTag()
-                |    }
+                |${TAB}return %2T.newPullParser().apply {
+                |${TAB}${TAB}setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
+                |${TAB}${TAB}setInput(inputStream, null)
+                |${TAB}${TAB}nextTag()
+                |${TAB}}
                 |}
                 |
                 """.trimMargin(),
@@ -73,11 +73,11 @@ class ExtensionGenerator(
             |if (next() == XmlPullParser.TEXT) {
             |content = text
             |nextTag()
-            |    if (eventType != XmlPullParser.END_TAG) {
-            |      skip()
-            |      nextTag()
-            |      content = null
-            |    }
+            |${TAB}if (eventType != XmlPullParser.END_TAG) {
+            |${TAB}${TAB}skip()
+            |${TAB}${TAB}nextTag()
+            |${TAB}${TAB}content = null
+            |${TAB}}
             |}
             |require(XmlPullParser.END_TAG, null, tagName)
             |return content
@@ -91,14 +91,14 @@ class ExtensionGenerator(
         .addCode(
             """
             |if (eventType != XmlPullParser.START_TAG) {
-            |  throw IllegalStateException()
+            |${TAB}throw IllegalStateException()
             |}
             |var depth = 1
             |while (depth != 0) {
-            |    when (next()) {
-            |        XmlPullParser.END_TAG -> depth--
-            |        XmlPullParser.START_TAG -> depth++
-            |    }
+            |${TAB}when (next()) {
+            |${TAB}${TAB}XmlPullParser.END_TAG -> depth--
+            |${TAB}${TAB}XmlPullParser.START_TAG -> depth++
+            |${TAB}}
             |}
             """.trimMargin()
         )
@@ -109,11 +109,9 @@ class ExtensionGenerator(
         .addCode(
             """
             |return when (toLowerCase()) {
-            |    "true" -> true
-            |    "false" -> false
-            |    "yes" -> true
-            |    "no" -> false
-            |    else -> null
+            |${TAB}"true", "yes" -> true
+            |${TAB}"no", "false" -> false
+            |${TAB}else -> null
             |}
         """.trimMargin()
         )

--- a/processor/src/main/java/tw/ktrssreader/processor/generator/ParserGenerator.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/generator/ParserGenerator.kt
@@ -138,7 +138,7 @@ class ParserGenerator(
         // Generate constructor statements
         propertyToParseData.forEach { generateConstructor(it, funSpec) }
 
-        funSpec.addStatement("\t)")
+        funSpec.addStatement("$TAB)")
         return funSpec.build()
     }
 
@@ -301,7 +301,7 @@ class ParserGenerator(
 
                 if (listItemType.isPrimitive()) {
                     data.tagCandidates.forEach { tag ->
-                        val statement = "\t\t\"$tag\" -> %1M(\"$tag\")"
+                        val statement = "$TAB$TAB\"$tag\" -> %1M(\"$tag\")"
                         funSpec.addPrimitiveStatement(statement, listItemType)
                         funSpec.addStatement("?.let { ${name.getVariableName(tag)}.add(it) }")
                     }
@@ -309,7 +309,7 @@ class ParserGenerator(
                     data.tagCandidates.forEach { tag ->
                         val memberName =
                             MemberName(listItemType.getGeneratedClassPath(), tag.getFuncName())
-                        funSpec.addStatement("\t\t\"$tag\" -> ${name.getVariableName(tag)}.add(%M())", memberName)
+                        funSpec.addStatement("$TAB$TAB\"$tag\" -> ${name.getVariableName(tag)}.add(%M())", memberName)
                     }
                 }
             }
@@ -319,7 +319,7 @@ class ParserGenerator(
                 data.tagCandidates.forEach { tag ->
                     val variableName = name.getVariableName(tag)
                     funSpec.addPrimitiveStatement(
-                        "\t\t\"$tag\" -> $variableName = %1M(\"$tag\")",
+                        "$TAB$TAB\"$tag\" -> $variableName = %1M(\"$tag\")",
                         type
                     )
                 }
@@ -333,7 +333,7 @@ class ParserGenerator(
                 data.tagCandidates.forEach { tag ->
                     val memberName = MemberName(type.getGeneratedClassPath(), tag.getFuncName())
                     funSpec.addStatement(
-                        "\t\t\"$tag\" -> ${name.getVariableName(tag)} = %M()",
+                        "$TAB$TAB\"$tag\" -> ${name.getVariableName(tag)} = %M()",
                         memberName
                     )
                 }
@@ -352,7 +352,7 @@ class ParserGenerator(
         if (dataType == DataType.VALUE) {
             val name = parseData.key
             val type = parseData.value.type ?: return
-            val statement = "\t\t$name = %M(\"$rootTagName\")".appendTypeConversion(type)
+            val statement = "$TAB$TAB$name = %M(\"$rootTagName\")".appendTypeConversion(type)
             if (type.equals(Boolean::class.java.simpleName, ignoreCase = true)) {
                 funSpec.addStatement(statement, readStringMemberName, booleanConversionMemberName)
             } else {
@@ -377,7 +377,7 @@ class ParserGenerator(
                 }
             }
         }
-        funSpec.addStatement("\t\t${parseData.key} = $stringBuilder,")
+        funSpec.addStatement("$TAB$TAB${parseData.key} = $stringBuilder,")
     }
 
     private fun getTagCandidates(

--- a/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
@@ -16,13 +16,11 @@
 
 package tw.ktrssreader.processor.util
 
-import tw.ktrssreader.processor.const.GENERATOR_PACKAGE
-import tw.ktrssreader.processor.const.GOOGLE_PREFIX
-import tw.ktrssreader.processor.const.ITUNES_PREFIX
-import tw.ktrssreader.processor.const.PARSER_SUFFIX
+import tw.ktrssreader.processor.const.*
 import java.util.*
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
+import javax.lang.model.element.Name
 import javax.lang.model.element.PackageElement
 import kotlin.reflect.KClass
 
@@ -82,3 +80,43 @@ fun Element.getPackage(): String {
 
     return (thisElement as PackageElement).qualifiedName.toString()
 }
+
+fun String.getVariableName(tag: String): String {
+    return when {
+        tag.startsWith(GOOGLE_PREFIX) -> "$this${GOOGLE_PREFIX.capitalize(Locale.ROOT)}"
+        tag.startsWith(ITUNES_PREFIX) -> "$this${ITUNES_PREFIX.capitalize(Locale.ROOT)}"
+        else -> this
+    }
+}
+
+fun String.appendTypeConversion(typeString: String): String {
+    return when {
+        typeString.contains(String::class.java.simpleName, ignoreCase = true) -> this
+        typeString.contains(Integer::class.java.simpleName, ignoreCase = true) -> "$this?.toIntOrNull()"
+        typeString.contains(Boolean::class.java.simpleName, ignoreCase = true) -> "$this?.%M()"
+        typeString.contains(Long::class.java.simpleName, ignoreCase = true) -> "$this?.toLongOrNull()"
+        typeString.contains(Short::class.java.simpleName, ignoreCase = true) -> "$this?.toShortOrNull()"
+        else -> this
+    }
+}
+
+fun Name.extractNameFromMethod(): String {
+    val withoutPrefix = if (startsWith(GET_PREFIX)) {
+        // Extract name which is started with 'get' (length = 3).
+        // The example: getList$annotations
+        substring(3)
+    } else {
+        // If the name is started with 'is', we preserve it.
+        // The example: isList$annotations
+        this.toString()
+    }
+
+    return withoutPrefix
+        .decapitalize(Locale.ROOT)
+        .substringBeforeLast('$')
+}
+
+fun Name.isGetterMethod(): Boolean {
+    return startsWith(GET_PREFIX) || startsWith(IS_PREFIX)
+}
+

--- a/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
@@ -104,7 +104,7 @@ fun Name.extractNameFromMethod(): String {
     val withoutPrefix = if (startsWith(GET_PREFIX)) {
         // Extract name which is started with 'get' (length = 3).
         // The example: getList$annotations
-        substring(3)
+        substring(GET_PREFIX.length)
     } else {
         // If the name is started with 'is', we preserve it.
         // The example: isList$annotations

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/Const.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/Const.kt
@@ -14,20 +14,6 @@
  *    limitations under the License.
  */
 
-package tw.ktrssreader.processor
+package tw.ktrssreader.processor.test
 
-import javax.lang.model.element.Element
-
-data class ParseData(
-    val type: String?,
-    val rawType: String?,
-    val dataType: DataType,
-    val listItemType: String?,
-    val packageName: String?,
-    val processorElement: Element,
-    val tagCandidates: List<String> = listOf()
-)
-
-enum class DataType {
-    PRIMITIVE, LIST, ATTRIBUTE, VALUE, OTHER
-}
+const val RSS_FOLDER = "RSS"

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserOrderTest.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserOrderTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Feng Hsien Hsu, Siao Syuan Yang, Wei-Qi Wang, Ya-Han Tsai, Yu Hao Wu
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package tw.ktrssreader.processor.test
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import tw.ktrssreader.generated.RssMixDataParser
+import tw.ktrssreader.test.common.XmlFileReader
+import tw.ktrssreader.test.common.shouldBe
+
+class CustomParserOrderTest {
+
+    @RunWith(Parameterized::class)
+    class RssStandardParserParseFunctionTest(
+        private val rssFilePath: String,
+        private val expectedChannel: RssMixData?
+    ) {
+        // TODO: More tests
+
+        @Test
+        fun parse() {
+            val xml = XmlFileReader.readFile(rssFilePath)
+            val actualChannel = RssMixDataParser.parse(xml)
+
+            actualChannel shouldBe expectedChannel
+        }
+    }
+}

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserTest.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserTest.kt
@@ -19,7 +19,7 @@ package tw.ktrssreader.processor.test
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import tw.ktrssreader.generated.RssTestDataParser
+import tw.ktrssreader.generated.TestRssDataParser
 import tw.ktrssreader.processor.test.data.TestData
 import tw.ktrssreader.test.common.XmlFileReader
 import tw.ktrssreader.test.common.shouldBe
@@ -29,7 +29,7 @@ class CustomParserTest {
     @RunWith(Parameterized::class)
     class RssStandardParserParseFunctionTest(
         private val rssFilePath: String,
-        private val expectedChannel: RssTestData?
+        private val expectedChannel: TestRssData?
     ) {
         companion object {
             @JvmStatic
@@ -46,7 +46,7 @@ class CustomParserTest {
         @Test
         fun parse() {
             val xml = XmlFileReader.readFile(rssFilePath)
-            val actualChannel = RssTestDataParser.parse(xml)
+            val actualChannel = TestRssDataParser.parse(xml)
 
             actualChannel shouldBe expectedChannel
         }

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserTest.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserTest.kt
@@ -17,37 +17,36 @@
 package tw.ktrssreader.processor.test
 
 import org.junit.Test
-import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import tw.ktrssreader.generated.RssDataParser
+import tw.ktrssreader.generated.RssTestDataParser
 import tw.ktrssreader.processor.test.data.TestData
 import tw.ktrssreader.test.common.XmlFileReader
 import tw.ktrssreader.test.common.shouldBe
 
-@RunWith(Enclosed::class)
-class RssTagParserTest {
+class CustomParserTest {
 
     @RunWith(Parameterized::class)
     class RssStandardParserParseFunctionTest(
         private val rssFilePath: String,
-        private val expectedChannel: RssData?
+        private val expectedChannel: RssTestData?
     ) {
-        // TODO: More tests.
         companion object {
             @JvmStatic
             @Parameterized.Parameters
             fun getTestingData() = listOf(
-                arrayOf("RSS/rss_v2_full.xml", TestData.RSS_DATA),
+                arrayOf("${RSS_FOLDER}/rss_v2_full.xml", TestData.RSS_DATA),
+                arrayOf("${RSS_FOLDER}/rss_v2_has_non_channel_attrs.xml", TestData.RSS_DATA),
+                arrayOf("${RSS_FOLDER}/rss_v2_has_non_channel_attrs_follow_behind.xml", TestData.RSS_DATA),
+                arrayOf("${RSS_FOLDER}/rss_v2_has_non_item_attrs.xml", TestData.RSS_DATA),
+                arrayOf("${RSS_FOLDER}/rss_v2_has_non_item_attrs_follow_behind.xml", TestData.RSS_DATA),
             )
         }
-
-        private val rssStandardParser: RssDataParser = RssDataParser
 
         @Test
         fun parse() {
             val xml = XmlFileReader.readFile(rssFilePath)
-            val actualChannel = rssStandardParser.parse(xml)
+            val actualChannel = RssTestDataParser.parse(xml)
 
             actualChannel shouldBe expectedChannel
         }

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/data/TestData.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/data/TestData.kt
@@ -20,7 +20,7 @@ import tw.ktrssreader.processor.test.*
 
 class TestData {
     companion object {
-        val RSS_DATA: RssTestData  = RssTestData(
+        val RSS_DATA: TestRssData  = TestRssData(
             title = "channel title",
             link = "http://channel.link",
             textInput = MyTextInput(title = "channel textInput title", name = "channel textInput name"),

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/data/TestData.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/data/TestData.kt
@@ -20,16 +20,23 @@ import tw.ktrssreader.processor.test.*
 
 class TestData {
     companion object {
-        val RSS_DATA: RssData  = RssData(
+        val RSS_DATA: RssTestData  = RssTestData(
             title = "channel title",
             link = "http://channel.link",
             textInput = MyTextInput(title = "channel textInput title", name = "channel textInput name"),
             list = listOf(
-                RssItem(title = "item title - Full", author = "item.author@example.com"),
-                RssItem(title = "item title - Partial", author = null),
-                RssItem(title = null, author = null)
+                RssItem(title = "item title - Full", author = "item.author@example.com", guid = TestGuid(null)),
+                RssItem(title = "item title - Partial", author = null, guid = TestGuid(true)),
+                RssItem(title = null, author = null, guid = null)
             ),
-            categories = listOf("channel category 1", "channel category 2"),
+            categories = listOf(
+                TestCategory(domain = null,
+                    categoryValue = "channel category 1"
+                ),
+                TestCategory(domain = "http://channel.category.domain",
+                    categoryValue = "channel category 2"
+                ),
+            ),
             skipDays = SkipDays(listOf("Saturday", "Sunday")),
             ttl = 60L,
             image = TestImage(
@@ -37,7 +44,8 @@ class TestData {
                 title = "channel image title",
                 height = 32,
                 width = 96
-            )
+            ),
+            cloud = TestCloud(domain = "channel.cloud.domain", testPort = 80, path = "/RPC2")
         )
     }
 }

--- a/processorTest/src/main/java/tw/ktrssreader/processor/test/RssMixData.kt
+++ b/processorTest/src/main/java/tw/ktrssreader/processor/test/RssMixData.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Feng Hsien Hsu, Siao Syuan Yang, Wei-Qi Wang, Ya-Han Tsai, Yu Hao Wu
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package tw.ktrssreader.processor.test
+
+import tw.ktrssreader.annotation.OrderType
+import tw.ktrssreader.annotation.RssAttribute
+import tw.ktrssreader.annotation.RssTag
+import java.io.Serializable
+
+@RssTag(name = "channel")
+data class RssMixData(
+    val title: String?,
+    @RssTag
+    val link: String?,
+    val textInput: MixTextInput?,
+    @RssTag(name = "item")
+    val list: List<RssMixItem>,
+    @RssTag(name = "category", order = [OrderType.ITUNES, OrderType.GOOGLE, OrderType.RSS_STANDARD])
+    val categories: List<String>,
+    val ttl: Long?,
+    val image: MixImage?,
+    val cloud: MixCloud?,
+): Serializable
+
+@RssTag(name = "textInput")
+data class MixTextInput(
+    val title: String?,
+    val name: String?
+): Serializable
+
+@RssTag(name = "item")
+data class RssMixItem(
+    @RssTag(order = [OrderType.ITUNES, OrderType.RSS_STANDARD, OrderType.GOOGLE])
+    val title: String?,
+    @RssTag(order = [OrderType.GOOGLE, OrderType.ITUNES, OrderType.RSS_STANDARD])
+    val author: String?,
+): Serializable
+
+@RssTag(name = "image")
+data class MixImage(
+    val link: String?,
+    val title: String?,
+    val height: Int?,
+    val width: Int?
+)
+
+@RssTag(name = "cloud")
+data class MixCloud(
+    @RssAttribute
+    val domain: String?,
+    @RssAttribute(name = "testPort")
+    val testPort: Int?,
+    @RssAttribute(name = "path")
+    val path: String?
+)

--- a/processorTest/src/main/java/tw/ktrssreader/processor/test/RssTestData.kt
+++ b/processorTest/src/main/java/tw/ktrssreader/processor/test/RssTestData.kt
@@ -16,21 +16,25 @@
 
 package tw.ktrssreader.processor.test
 
+import tw.ktrssreader.annotation.RssAttribute
 import tw.ktrssreader.annotation.RssTag
+import tw.ktrssreader.annotation.RssValue
 import java.io.Serializable
 
 @RssTag(name = "channel")
-data class RssData(
+data class RssTestData(
     val title: String?,
+    @RssTag
     val link: String?,
     val textInput: MyTextInput?,
     @RssTag(name = "item")
     val list: List<RssItem>,
     @RssTag(name = "category")
-    val categories: List<String>,
+    val categories: List<TestCategory>,
     val skipDays: SkipDays?,
     val ttl: Long?,
     val image: TestImage?,
+    val cloud: TestCloud?,
 ): Serializable
 
 @RssTag(name = "textInput")
@@ -43,6 +47,7 @@ data class MyTextInput(
 data class RssItem(
     val title: String?,
     val author: String?,
+    val guid: TestGuid?
 ): Serializable
 
 @RssTag(name = "image")
@@ -51,10 +56,34 @@ data class TestImage(
     val title: String?,
     val height: Int?,
     val width: Int?
-)
+): Serializable
 
 @RssTag(name = "skipDays")
 data class SkipDays(
     @RssTag(name = "day")
     val days: List<String>,
-)
+): Serializable
+
+@RssTag(name = "cloud")
+data class TestCloud(
+    @RssAttribute
+    val domain: String?,
+    @RssAttribute(name = "port")
+    val testPort: Int?,
+    @RssAttribute(name = "path")
+    val path: String?
+): Serializable
+
+@RssTag(name = "guid")
+data class TestGuid(
+    @RssAttribute
+    val isPermaLink: Boolean?
+): Serializable
+
+@RssTag(name = "category")
+data class TestCategory(
+    @RssAttribute
+    val domain: String?,
+    @RssValue
+    val categoryValue: String?
+): Serializable

--- a/processorTest/src/main/java/tw/ktrssreader/processor/test/TestRssData.kt
+++ b/processorTest/src/main/java/tw/ktrssreader/processor/test/TestRssData.kt
@@ -22,7 +22,7 @@ import tw.ktrssreader.annotation.RssValue
 import java.io.Serializable
 
 @RssTag(name = "channel")
-data class RssTestData(
+data class TestRssData(
     val title: String?,
     @RssTag
     val link: String?,


### PR DESCRIPTION
## Added
- New annotation: `@RssValue` to parse values for tags.
  For example:
  ```xml
  <category domain="the domain">category name</category>
  ```
  The data class will be like...
  ```kotlin
  @RssTag(name = "category")
  data class MyCategory(
      @RssValue
      val name: String?,
      @RssAttribute
      val domain: String?
  )
  ```
  `MyCategory.name` will be `category name` in this case.
- Standard RSS tests.
- Classes to prepare to test parsing orders.
## Modified
- Use tab escape character, tab `\t`, to make generated code more readable.
## TODO
- Parsing order tests.
- `@RssRawTag` tests.