### PR TITLE
Add @RssRawData tests.

### DIFF
--- a/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/util/Extensions.kt
@@ -82,10 +82,11 @@ fun Element.getPackage(): String {
 }
 
 fun String.getVariableName(tag: String): String {
+    val tagCapitalized = tag.substringAfterLast(':').capitalize(Locale.ROOT)
     return when {
-        tag.startsWith(GOOGLE_PREFIX) -> "$this${GOOGLE_PREFIX.capitalize(Locale.ROOT)}"
-        tag.startsWith(ITUNES_PREFIX) -> "$this${ITUNES_PREFIX.capitalize(Locale.ROOT)}"
-        else -> this
+        tag.startsWith(GOOGLE_PREFIX) -> "$this${GOOGLE_PREFIX.capitalize(Locale.ROOT)}$tagCapitalized"
+        tag.startsWith(ITUNES_PREFIX) -> "$this${ITUNES_PREFIX.capitalize(Locale.ROOT)}$tagCapitalized"
+        else -> "$this$tagCapitalized"
     }
 }
 

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserRawDataTest.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/CustomParserRawDataTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Feng Hsien Hsu, Siao Syuan Yang, Wei-Qi Wang, Ya-Han Tsai, Yu Hao Wu
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package tw.ktrssreader.processor.test
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import tw.ktrssreader.generated.RawRssDataParser
+import tw.ktrssreader.processor.test.data.TestData
+import tw.ktrssreader.test.common.XmlFileReader
+import tw.ktrssreader.test.common.shouldBe
+
+class CustomParserRawDataTest {
+    @RunWith(Parameterized::class)
+    class CustomParserRawParseFunctionTest(
+        private val rssFilePath: String,
+        private val expectedChannel: RawRssData?
+    ) {
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters
+            fun getTestingData() = listOf(
+                arrayOf("$MIX_FOLDER/rss_v2_itunes_google_full.xml", TestData.RAW_RSS_DATA_1),
+                arrayOf("$MIX_FOLDER/rss_v2_itunes_google_category_no_ordering.xml", TestData.RAW_RSS_DATA_1),
+                arrayOf("$MIX_FOLDER/rss_v2_itunes_google_without_items.xml", TestData.RAW_RSS_DATA_2),
+                arrayOf("$MIX_FOLDER/rss_v2_itunes_google_without_itunes_attrs.xml", TestData.RAW_RSS_DATA_3),
+            )
+        }
+        @Test
+        fun parse() {
+            val xml = XmlFileReader.readFile(rssFilePath)
+            val actualChannel = RawRssDataParser.parse(xml)
+
+            actualChannel shouldBe expectedChannel
+        }
+    }
+}

--- a/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/data/TestData.kt
+++ b/processorTest/src/androidTest/java/tw/ktrssreader/processor/test/data/TestData.kt
@@ -219,5 +219,54 @@ class TestData {
                 href = null
             )
         )
+        val RAW_RSS_DATA_1: RawRssData = RawRssData(
+            author = "channel author - google play",
+            owner = RawOwner(
+                name = "channel owner name - iTunes",
+                email = "channel.owner.email.itunes@example.com"
+            ),
+            list = listOf(
+                RawRssItem(
+                    info = "item author - iTunes",
+                    link = "http://item.link",
+                    enclosure = RawEnclosure(
+                        length = 24986239,
+                        url = "http://item.enclosure.url/item.mp3"
+                    ),
+                    explicit = true
+                ),
+                RawRssItem(
+                    info = "item author - iTunes",
+                    link = "http://item.link",
+                    enclosure = RawEnclosure(
+                        length = 24986239,
+                        url = "http://item.enclosure.url/item.mp3"
+                    ),
+                    explicit = true
+                ),
+                RawRssItem(
+                    info = "item title - Partial",
+                    link = "http://item.link",
+                    enclosure = RawEnclosure(
+                        length = 24986239,
+                        url = "http://item.enclosure.url/item.mp3"
+                    ),
+                    explicit = true
+                ),
+            )
+        )
+        val RAW_RSS_DATA_2: RawRssData = RawRssData(
+            author = "channel author - google play",
+            owner = RawOwner(
+                name = "channel owner name - iTunes",
+                email = "channel.owner.email.itunes@example.com"
+            ),
+            list = listOf()
+        )
+        val RAW_RSS_DATA_3: RawRssData = RawRssData(
+            author = "channel author - google play",
+            owner = null,
+            list = listOf()
+        )
     }
 }

--- a/processorTest/src/main/java/tw/ktrssreader/processor/test/RawRssData.kt
+++ b/processorTest/src/main/java/tw/ktrssreader/processor/test/RawRssData.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Feng Hsien Hsu, Siao Syuan Yang, Wei-Qi Wang, Ya-Han Tsai, Yu Hao Wu
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package tw.ktrssreader.processor.test
+
+import tw.ktrssreader.annotation.RssAttribute
+import tw.ktrssreader.annotation.RssRawData
+import tw.ktrssreader.annotation.RssTag
+import java.io.Serializable
+
+@RssTag(name = "channel")
+data class RawRssData(
+    @RssRawData(["googleplay:author", "googleplay:owner"])
+    val author: String?,
+    @RssRawData(["itunes:owner"])
+    val owner: RawOwner?,
+    @RssTag(name = "item")
+    val list: List<RawRssItem>,
+): Serializable
+
+@RssTag(name = "item")
+data class RawRssItem(
+    @RssRawData(["itunes:author", "title", "googleplay:description"])
+    val info: String?,
+    val link: String?,
+    val enclosure: RawEnclosure?,
+    @RssRawData(["itunes:explicit", "googleplay:explicit"])
+    val explicit: Boolean?,
+)
+
+@RssTag(name = "enclosure")
+data class RawEnclosure(
+    @RssAttribute
+    val length: Long?,
+    @RssAttribute
+    val url: String?,
+)
+
+@RssTag(name = "owner")
+data class RawOwner(
+    val name: String?,
+    val email: String?,
+): Serializable


### PR DESCRIPTION
- Add @RssRawData tests.
- Avoid naming conflict of the generated parser's variables if the user annotates different raw tags on the same value.
> For example,
>   ```kotlin
>   @RssRawData(["googleplay:author", "googleplay:owner"])
>   val info: String?
>   ```
>   Before this PR, the generated variables will conflict... 🙅🏻
>  ```kotlin
>  var infoGoogleplay: String? = null
>  var infoGoogleplay: String? = null
>  ```
>  Then, we got compiler errors.
>  After a proper modification, the variables in the generated parser will be...
>  ```kotlin
>  var infoGoogleplayAuthor: String? = null
>  var infoGoogleplayOwner: String? = null
>  ```
>  Now, it all works! 🙆🏻