### PR TITLE
Implement App Startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,20 +249,16 @@ Reader.clearCache()
 
 ### Global Config
 
-To let KtRssReader works with the database, you need to set the application context in your application.
-
 ```kotlin
 class MyApplication : Application() {
     override fun onCreate() {
         readerGlobalConfig {
-            setApplicationContext(this@MyApplication)
             enableLog = true
         }
     }
 }
 ```
 
-* `setApplicationContext()`: The application context.
 * `enableLog`: If this is enabled, the debug log will be shown on the console.
 
 ### Reader Config

--- a/app/src/main/java/tw/ktrssreader/SampleApplication.kt
+++ b/app/src/main/java/tw/ktrssreader/SampleApplication.kt
@@ -8,7 +8,6 @@ class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         readerGlobalConfig {
-            setApplicationContext(this@SampleApplication)
             enableLog = true
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         def coroutines_version = '1.3.9'
         def okhttp_version = '4.9.0'
         def room_version = '2.2.5'
+        def startup_version = '1.0.0'
 
         def mockk_version = '1.10.0'
         def turbine_version = '0.2.1'
@@ -16,6 +17,7 @@ buildscript {
                 'roomRuntime'             : "androidx.room:room-runtime:$room_version",
                 'roomKtx'                 : "androidx.room:room-ktx:$room_version",
                 'roomCompiler'            : "androidx.room:room-compiler:$room_version",
+                'startup'                 : "androidx.startup:startup-runtime:$startup_version"
         ]
         testDeps = [
                 'mockk'  : "io.mockk:mockk:$mockk_version",

--- a/ktRssReader/build.gradle
+++ b/ktRssReader/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     implementation deps.roomKtx
     kapt deps.roomCompiler
 
+    implementation deps.startup
+
     testImplementation testDeps.mockk
     testImplementation testDeps.turbine
 

--- a/ktRssReader/src/main/AndroidManifest.xml
+++ b/ktRssReader/src/main/AndroidManifest.xml
@@ -1,5 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="tw.ktrssreader">
 
-    /
+    <application>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+
+            <meta-data
+                android:name="tw.ktrssreader.KtRssReaderInitializer"
+                android:value="androidx.startup" />
+        </provider>
+    </application>
+
 </manifest>

--- a/ktRssReader/src/main/java/tw/ktrssreader/KtRssReader.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/KtRssReader.kt
@@ -18,7 +18,6 @@ package tw.ktrssreader
 
 import kotlinx.coroutines.flow.flow
 import tw.ktrssreader.config.KtRssReaderConfig
-import tw.ktrssreader.config.KtRssReaderGlobalConfig
 import tw.ktrssreader.constant.Const
 import tw.ktrssreader.provider.KtRssProvider
 import tw.ktrssreader.utils.ThreadUtils
@@ -98,7 +97,9 @@ object Reader {
         url: String,
         crossinline customParser: ((String) -> T?) = { null },
         crossinline config: Config = {}
-    ) = suspendCoroutine<T> { it.resume(read(url = url, customParser = customParser, config = config)) }
+    ) = suspendCoroutine<T> {
+        it.resume(read(url = url, customParser = customParser, config = config))
+    }
 
     inline fun <reified T> flowRead(
         url: String,
@@ -108,7 +109,7 @@ object Reader {
 
     fun clearCache() {
         ThreadUtils.runOnNewThread("[clear cache]") {
-            val db = KtRssProvider.provideDatabase(KtRssReaderGlobalConfig.getApplicationContext())
+            val db = KtRssProvider.provideDatabase(KtRssReaderInitializer.applicationContext)
             db.channelDao().clearAll()
         }
     }

--- a/ktRssReader/src/main/java/tw/ktrssreader/KtRssReaderInitializer.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/KtRssReaderInitializer.kt
@@ -1,0 +1,19 @@
+package tw.ktrssreader
+
+import android.content.Context
+import androidx.startup.Initializer
+
+class KtRssReaderInitializer : Initializer<Unit> {
+
+    companion object {
+        lateinit var applicationContext: Context
+    }
+
+    override fun create(context: Context) {
+        applicationContext = context
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> {
+        return emptyList()
+    }
+}

--- a/ktRssReader/src/main/java/tw/ktrssreader/cache/DatabaseRssCache.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/cache/DatabaseRssCache.kt
@@ -16,7 +16,7 @@
 
 package tw.ktrssreader.cache
 
-import tw.ktrssreader.config.KtRssReaderGlobalConfig
+import tw.ktrssreader.KtRssReaderInitializer
 import tw.ktrssreader.constant.Const
 import tw.ktrssreader.persistence.db.entity.ChannelEntity
 import tw.ktrssreader.provider.KtRssProvider
@@ -28,7 +28,7 @@ import java.util.*
 class DatabaseRssCache<T> : RssCache<T> {
 
     private val logTag = this::class.java.simpleName
-    private val db = KtRssProvider.provideDatabase(KtRssReaderGlobalConfig.getApplicationContext())
+    private val db = KtRssProvider.provideDatabase(KtRssReaderInitializer.applicationContext)
     private val dao = db.channelDao()
 
     override fun readCache(url: String, type: @Const.ChannelType Int, expiredTimeMillis: Long): T? {

--- a/ktRssReader/src/main/java/tw/ktrssreader/config/KtRssReaderGlobalConfig.kt
+++ b/ktRssReader/src/main/java/tw/ktrssreader/config/KtRssReaderGlobalConfig.kt
@@ -16,20 +16,8 @@
 
 package tw.ktrssreader.config
 
-import android.content.Context
-
 object KtRssReaderGlobalConfig {
-    private var applicationContext: Context? = null
     var enableLog: Boolean = false
-
-    fun setApplicationContext(applicationContext: Context) {
-        this.applicationContext = applicationContext
-    }
-
-    fun getApplicationContext(): Context {
-        return applicationContext
-            ?: error("No Application Context configured. Please use readerGlobalConfig() DSL.")
-    }
 }
 
 fun readerGlobalConfig(builder: KtRssReaderGlobalConfig.() -> Unit) {


### PR DESCRIPTION
加入 startup lib ，使用者不再需要設置 `setApplicationContext `

[]((https://developer.android.com/topic/libraries/app-startup))