### PR TITLE
Remove `DeferredElementImpl` from `ParserBase` and fix Room database compiler error

### DIFF
--- a/android/src/main/java/tw/ktrssreader/persistence/db/KtRssReaderDatabase.kt
+++ b/android/src/main/java/tw/ktrssreader/persistence/db/KtRssReaderDatabase.kt
@@ -23,7 +23,11 @@ import androidx.room.RoomDatabase
 import tw.ktrssreader.persistence.db.dao.ChannelDao
 import tw.ktrssreader.persistence.db.entity.ChannelEntity
 
-@Database(entities = [ChannelEntity::class], version = KtRssReaderDatabase.DB_VERSION)
+@Database(
+    entities = [ChannelEntity::class],
+    version = KtRssReaderDatabase.DB_VERSION,
+    exportSchema = false
+)
 abstract class KtRssReaderDatabase : RoomDatabase() {
 
     companion object {

--- a/kotlin/src/main/java/tw/ktrssreader/kotlin/parser/ParserBase.kt
+++ b/kotlin/src/main/java/tw/ktrssreader/kotlin/parser/ParserBase.kt
@@ -17,7 +17,6 @@
 
 package tw.ktrssreader.kotlin.parser
 
-import com.sun.org.apache.xerces.internal.dom.DeferredElementImpl
 import org.w3c.dom.Element
 import tw.ktrssreader.kotlin.constant.ParserConst.CATEGORY
 import tw.ktrssreader.kotlin.constant.ParserConst.CHANNEL
@@ -102,7 +101,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
 
         for (i in 0 until nodeList.length) {
             val e = nodeList.item(i) as? Element ?: continue
-            val parent = e.parentNode as? DeferredElementImpl
+            val parent = e.parentNode as? Element
             if (parent?.tagName != parentTag) continue
 
             val domain: String? = e.getAttributeOrNull(DOMAIN)
@@ -118,7 +117,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
 
         for (i in 0 until nodeList.length) {
             val e = nodeList.item(i) as? Element ?: continue
-            val parent = e.parentNode as? DeferredElementImpl
+            val parent = e.parentNode as? Element
             if (parent?.tagName == parentTag || parent?.tagName == tagName) {
                 result.add(Category(name = e.getAttributeOrNull(TEXT), domain = null))
             }
@@ -227,7 +226,7 @@ abstract class ParserBase<out T : RssStandardChannel> : Parser<T> {
         } else {
             for (i in 0 until nodeList.length) {
                 val e = nodeList.item(i) as? Element ?: continue
-                val parent = e.parentNode as? DeferredElementImpl
+                val parent = e.parentNode as? Element
                 if (parent?.tagName != parentTag) continue
 
                 return e.textContent


### PR DESCRIPTION
1. We used the internal Java `DeferredElementImpl` class, this PR removed it from `ParserBase`.
```
IllegalAccessError: cannot access class com.sun.org.apache.xerces.internal.dom.DeferredElementImpl
```
2. Fix Room database compiler error by adding an extra attribute in `@Database`.