### PR TITLE
Allow users to customize  fetcher

### DIFF
--- a/android/src/main/java/tw/ktrssreader/KtRssReader.kt
+++ b/android/src/main/java/tw/ktrssreader/KtRssReader.kt
@@ -125,7 +125,7 @@ object Reader {
                 customFetcher = customFetcher,
                 config = config
             )
-        ) 
+        )
     }
 
     fun clearCache() {

--- a/android/src/main/java/tw/ktrssreader/KtRssReader.kt
+++ b/android/src/main/java/tw/ktrssreader/KtRssReader.kt
@@ -101,12 +101,15 @@ object Reader {
         customFetcher: Fetcher? = null,
         crossinline config: Config = {}
     ) = suspendCoroutine<T> {
-        it.resume(read(
-            url = url,
-            customParser = customParser,
-            customFetcher = customFetcher,
-            config = config
-        ))
+        it.resume(
+            read(
+                url = url,
+                customParser = customParser,
+                customFetcher = customFetcher,
+                config = config
+
+            )
+        )
     }
 
     inline fun <reified T> flowRead(
@@ -114,12 +117,16 @@ object Reader {
         crossinline customParser: ((String) -> T?) = { null },
         customFetcher: Fetcher? = null,
         crossinline config: Config = {}
-    ) = flow<T> { emit(read(
-        url = url,
-        customParser = customParser,
-        customFetcher = customFetcher,
-        config = config
-    )) }
+    ) = flow<T> {
+        emit(
+            read(
+                url = url,
+                customParser = customParser,
+                customFetcher = customFetcher,
+                config = config
+            )
+        ) 
+    }
 
     fun clearCache() {
         ThreadUtils.runOnNewThread("[clear cache]") {


### PR DESCRIPTION
Context
--
Allow users to customize `Fetcher`, so they can set headers or use HTTP clients with different settings. Check out the [reported issue](https://github.com/ivanisidrowu/KtRssReader/issues/83).

Sample Usage
--
```kotlin
class XmlFetcher : Fetcher {

    override fun fetch(url: String, charset: Charset?): String {
        val request = Request.Builder()
            .url(url)
            .header("User-Agent", "custom user agent")
            .build()
        val response = OkHttpClient().newCall(request).execute()
        return response.body?.toString() ?: throw IOException("Failed to get the response body!")
    }

}
```