### PR TITLE
Fix kotlin 2.1 incompatibilities

### DIFF
--- a/android/src/main/java/tw/ktrssreader/config/KtRssReaderConfig.kt
+++ b/android/src/main/java/tw/ktrssreader/config/KtRssReaderConfig.kt
@@ -17,9 +17,8 @@
 package tw.ktrssreader.config
 
 import java.nio.charset.Charset
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 import kotlin.time.ExperimentalTime
-import kotlin.time.days
 
 class KtRssReaderConfig {
     var charset: Charset? = null
@@ -29,5 +28,5 @@ class KtRssReaderConfig {
     var flushCache: Boolean = false
 
     @ExperimentalTime
-    var expiredTimeMillis: Long = Duration.days(1).inWholeMilliseconds
+    var expiredTimeMillis: Long = 1.days.inWholeMilliseconds
 }

--- a/processor/src/main/java/tw/ktrssreader/processor/generator/ExtensionGenerator.kt
+++ b/processor/src/main/java/tw/ktrssreader/processor/generator/ExtensionGenerator.kt
@@ -26,7 +26,7 @@ abstract class ExtensionGenerator : Generator {
         .receiver(String::class)
         .addCode(
             """
-            |return when (toLowerCase()) {
+            |return when (lowercase()) {
             |$TAB"true", "yes" -> true
             |$TAB"no", "false" -> false
             |${TAB}else -> null


### PR DESCRIPTION
* `toLowerCase()` is deprecated, so changed to `lowercase()`.
* `Duration.days(X)` is replaced by inline extension property since the method was removed.